### PR TITLE
Allow omitting repetitive type annotations.

### DIFF
--- a/src/dsl/ContextMaps.jl
+++ b/src/dsl/ContextMaps.jl
@@ -78,6 +78,6 @@ end
 
 TheoryMacros.construct_context(judgments::Vector{Judgment}, ctx::Context) = ctx
 TheoryMacros.construct_context(judgments::Vector{Judgment}, exprs::Vector{Expr0}) =
-  construct_context(judgments, parse_binding.(exprs))
+  construct_context(judgments, parse_bindings(exprs))
 
 end

--- a/src/dsl/Parsing.jl
+++ b/src/dsl/Parsing.jl
@@ -114,17 +114,17 @@ function parse_declbody(e::Expr0)
 end
 
 function parse_bindings(bindings::AbstractVector)
-  result = Pair{Name, SymExpr}{}
+  result = Pair{Symbol, SymExpr}[]
   for binding in bindings
     @match binding begin
       :($(head::Symbol)::$(type::Expr0)) =>
-        push!(result, Name(head) => parse_symexpr(type))
-      :(($heads...,)::$(type::Expr0)) => begin
+        push!(result, head => parse_symexpr(type))
+      :(($(heads...),)::$(type::Expr0)) => begin
         type_expr = parse_symexpr(type)
-        append!(result, map(head -> Name(head) => type_expr, heads))
+        append!(result, map(head -> head => type_expr, heads))
       end
       :($(head::Symbol)) =>
-        push!(result, Name(head) => SymExpr(Name(:default)))
+        push!(result, head => SymExpr(Name(:default)))
       _ => error("could not parse binding $binding")
     end
   end

--- a/src/dsl/TheoryMacros.jl
+++ b/src/dsl/TheoryMacros.jl
@@ -235,7 +235,7 @@ end
 function context_impl(T::Type{<:AbstractTheory}, expr)
   T = gettheory(T)
   @match expr begin
-    :([$(bindings...)]) => construct_context(T.judgments, parse_binding.(bindings))
+    :([$(bindings...)]) => construct_context(T.judgments, parse_bindings(bindings))
     _ => error("expected a list of bindings")
   end
 end

--- a/test/logic/ContextMaps.jl
+++ b/test/logic/ContextMaps.jl
@@ -12,4 +12,13 @@ end
 @test length(f.dom) == 3
 @test index(f.values[3].head) == 3
 
+g = @context_map ThCategory [a,b::Ob, f::Hom(a,b)] [c,d::Ob, f::Hom(c,d)] begin
+  a = c
+  b = d
+  f = f
+end
+
+@test length(g.dom) == 3
+@test length(g.codom) == 3
+
 end

--- a/test/logic/ContextMaps.jl
+++ b/test/logic/ContextMaps.jl
@@ -12,7 +12,7 @@ end
 @test length(f.dom) == 3
 @test index(f.values[3].head) == 3
 
-g = @context_map ThCategory [a,b::Ob, f::Hom(a,b)] [c,d::Ob, f::Hom(c,d)] begin
+g = @context_map ThCategory [(a,b)::Ob, f::Hom(a,b)] [(c,d)::Ob, f::Hom(c,d)] begin
   a = c
   b = d
   f = f

--- a/test/stdlib/tests.jl
+++ b/test/stdlib/tests.jl
@@ -30,6 +30,11 @@ end
   ϕ(i, o)::XX ⊣ [i::XX,o::XX]
   ψ(k)::XX ⊣ [k::XX]
 end
+@theory T3 <: ThEmpty begin
+  A::TYPE ⊣ []
+  u(x, y, z)::A ⊣ [x,y,z::A]
+  u(x, y, z) == u(y, z, x) :: A ⊣ [x,y,z::A]
+end
 
 tst = @theorymap T1 -> T2 begin
   X => XX 

--- a/test/stdlib/tests.jl
+++ b/test/stdlib/tests.jl
@@ -32,8 +32,8 @@ end
 end
 @theory T3 <: ThEmpty begin
   A::TYPE ⊣ []
-  u(x, y, z)::A ⊣ [x,y,z::A]
-  u(x, y, z) == u(y, z, x) :: A ⊣ [x,y,z::A]
+  u(x, y, z)::A ⊣ [(x,y,z)::A]
+  u(x, y, z) == u(y, z, x) :: A ⊣ [(x,y,z)::A]
 end
 
 tst = @theorymap T1 -> T2 begin


### PR DESCRIPTION
My attempt to resolve #4.
So we can use `a,b,c::T` to denote the context `a::T,b::T,c::T`.