### PR TITLE
Syntax for using pushouts

### DIFF
--- a/src/stdlib/Algebra.jl
+++ b/src/stdlib/Algebra.jl
@@ -31,15 +31,15 @@ end
   a ⋅ b == b ⋅ a ⊣ [a,b]
 end
 
-# @theory ThAb <: ThMonoid begin
-#   using ThGroup
-#   using ThCMonoid
-# end
+@theory ThAb <: ThMonoid begin
+  using ThGroup
+  using ThCMonoid
+end
 
-# @theory ThRing <: ThSet begin
-#   using ThAb: ⋅ as +, e as 0
-#   using ThMonoid
-#   a ⋅ (b + c) == (a ⋅ b) + (a ⋅ c) ⊣ [a,b,c]
-# end
+@theory ThRing <: ThSet begin
+  using ThAb: ⋅ as +, e as 0
+  using ThMonoid
+  a ⋅ (b + c) == (a ⋅ b) + (a ⋅ c) ⊣ [a,b,c]
+end
 
 end

--- a/src/syntax/Theories.jl
+++ b/src/syntax/Theories.jl
@@ -1,7 +1,7 @@
 module Theories
 export Lvl, Typ, Trm, TypCon, TrmCon, Axiom, Context, Judgment, Theory,
   AbstractTheory, theory, empty_theory, ThEmpty, index, is_context, FullContext,
-  lookup, arity, judgments, rename
+  lookup, arity, judgments, rename, getname
 
 using StructEquality
 
@@ -73,7 +73,7 @@ end
 
 Base.:(==)(x::Judgment,y::Judgment) = x.head == y.head && x.ctx == y.ctx
 Base.hash(x::Judgment, h) = hash(x.head, hash(x.ctx, h))
-name(j::Judgment) = j.name
+getname(j::Judgment) = j.name
 rename(j::Judgment, n::Name) = Judgment(n, j.head, j.ctx)
 
 # Args index the CONTEXT of the judgment

--- a/src/util/Names.jl
+++ b/src/util/Names.jl
@@ -25,6 +25,7 @@ Name(n::String) = StrLit(n)
 Name(n::Char) = StrLit(string(n))
 Name(n::Symbol) = n == :default ? Default() : SymLit(n)
 Name(n::Name) = n
+Name(i::Int)= SymLit(Symbol(i))
 
 struct Anon <: Name
 end


### PR DESCRIPTION
This PR adds `using` syntax for constructing theories; see Algebras.jl for example usage.

The semantics for this are slightly janky. We assume that each theory that we include with `using` has the parent theory (i.e., when `ThRing <: ThSet` is the head of the theory, then `ThSet` is the parent) as a prefix.

We should later support more general theory inclusions.