### PR TITLE
DOCS: Add modules to api reference

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -40,6 +40,7 @@ makedocs(
     #   "examples/test_example/test_example.md",
     # ],
     "Library Reference"=>"api.md",
+    "Standard Library"=>"stdlib.md",
   ]
 )
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,5 +1,28 @@
 # Library Reference
 
 ```@autodocs
-Modules = [Gatlab]
+Modules = [Gatlab,
+  Gatlab.Util  ,
+  Gatlab.Util.Lists  ,
+  Gatlab.Util.Names  ,
+  Gatlab.Syntax,
+  Gatlab.Syntax.Theories,
+  Gatlab.Syntax.TheoryMaps,
+  Gatlab.Syntax.Pushouts,
+  Gatlab.Syntax.Visualization,
+  Gatlab.Logic ,
+  Gatlab.Logic.EGraphs,
+  Gatlab.Logic.EMatching,
+  Gatlab.Logic.ContextMaps,
+  Gatlab.Models,
+  Gatlab.Models.ModelInterface,
+  Gatlab.Models.Interpret,
+  Gatlab.Dsl   ,
+  Gatlab.Dsl.TheoryMacros           ,
+  Gatlab.Dsl.ContextMaps            ,
+  Gatlab.Dsl.ModelImplementations   ,
+  Gatlab.Stdlib,
+  Gatlab.Stdlib.Categories,
+  Gatlab.Stdlib.Algebra,
+  ]
 ```

--- a/docs/src/stdlib.md
+++ b/docs/src/stdlib.md
@@ -1,0 +1,8 @@
+# Standard Library
+
+```@autodocs
+Modules = [Gatlab.Stdlib,
+  Gatlab.Stdlib.Categories,
+  Gatlab.Stdlib.Algebra,
+  ]
+```


### PR DESCRIPTION
This PR adds the submodules to the API docs. @olynch, there are no docs generated for the stdlib. But I think we should have a central page for that. 