### PR TITLE
Serialization for Algebraic Lenses

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StructEquality = "6ec83bb0-ed9f-11e9-3b4c-2b04cb4e219c"

--- a/src/stdlib/Serialization.jl
+++ b/src/stdlib/Serialization.jl
@@ -1,0 +1,156 @@
+"""
+Serialization is fairly straightforward
+
+Terms and types both serialize as
+
+{
+  "head": Int
+  "args": [term...]
+}
+
+A context serializes as
+
+{
+  "ctx": [[name, typ]...]
+}
+
+
+"""
+module Serialization
+
+export parse_json
+
+import JSON
+import JSON.Writer: show_json, begin_object, show_pair, end_object, begin_array, end_array,
+  StructuralContext
+import JSON.Serializations: StandardSerialization
+using MLStyle
+
+using ..StdModels
+using ...Syntax
+using ...Util
+
+function show_json(io::StructuralContext, s::StandardSerialization, t::Union{Trm, Typ})
+  begin_object(io)
+  show_pair(io, s, :head => t.head)
+  show_pair(io, s, :args => t.args)
+  end_object(io)
+end
+
+function show_json(io::StructuralContext, s::StandardSerialization, lvl::Lvl)
+  begin_object(io)
+  show_pair(io, s, :is_context => is_context(lvl))
+  show_pair(io, s, :index => index(lvl))
+  end_object(io)
+end
+
+function show_json(io::StructuralContext, s::StandardSerialization, ctx::Context)
+  begin_object(io)
+  show_pair(io, s, :ctx => ctx.ctx)
+  end_object(io)
+end
+
+function show_json(io::StructuralContext, s::StandardSerialization, name::SymLit)
+  begin_object(io)
+  show_pair(io, s, :type => "SymLit")
+  show_pair(io, s, :value => name.name)
+  end_object(io)
+end
+
+function show_json(io::StructuralContext, s::StandardSerialization, name::StrLit)
+  begin_object(io)
+  show_pair(io, s, :type => "StrLit")
+  show_pair(io, s, :value => name.name)
+  end_object(io)
+end
+
+function show_json(io::StructuralContext, s::StandardSerialization, name::Default)
+  begin_object(io)
+  show_pair(io, s, :type => "Default")
+  end_object(io)
+end
+
+function show_json(io::StructuralContext, s::StandardSerialization, name::Anon)
+  begin_object(io)
+  show_pair(io, s, :type => "Anon")
+  end_object(io)
+end
+
+function show_json(io::StructuralContext, s::StandardSerialization, f::KleisliContextMap)
+  begin_object(io)
+  show_pair(io, s, :dom => f.dom)
+  show_pair(io, s, :codom => f.codom)
+  show_pair(io, s, :morphism => f.morphism)
+  end_object(io)
+end
+
+function show_json(io::StructuralContext, s::StandardSerialization, a::SimpleArena)
+  begin_object(io)
+  show_pair(io, s, :pos => a.pos)
+  show_pair(io, s, :dir => a.dir)
+  end_object(io)
+end
+
+function show_json(io::StructuralContext, s::StandardSerialization, l::SimpleKleisliLens)
+  begin_object(io)
+  show_pair(io, s, :dom => l.dom)
+  show_pair(io, s, :codom => l.codom)
+  show_pair(io, s, :expose => l.morphism.expose)
+  show_pair(io, s, :update => l.morphism.update)
+  end_object(io)
+end
+
+function parse_json(d::Dict, ::Type{T}) where {T <: Union{Trm, Typ}}
+  T(parse_json(d["head"], Lvl), parse_json.(d["args"], Ref(Trm)))
+end
+
+function parse_json(d::Dict, ::Type{Lvl})
+  Lvl(d["index"], context=d["is_context"])
+end
+
+function parse_json(d::Dict, ::Type{Context})
+  Context(parse_json.(d["ctx"], Ref(Tuple{Name, Typ})))
+end
+
+function parse_json(d::Vector, ::Type{Tuple{A,B}}) where {A,B}
+  (parse_json(d[1], A), parse_json(d[2], B))
+end
+
+function parse_json(d::Dict, ::Type{Name})
+  @match d["type"] begin
+    "SymLit" => SymLit(Symbol(d["value"]))
+    "StrLit" => StrLit(d["value"])
+    "Default" => Default()
+    "Anon" => Anon()
+  end
+end
+
+function parse_json(v::Vector, ::Type{Vector{T}}) where {T}
+  T[parse_json(x, T) for x in v]
+end
+
+function parse_json(d::Dict, ::Type{KleisliContextMap})
+  KleisliContextMap(
+    parse_json(d["dom"], Context),
+    parse_json(d["codom"], Context),
+    parse_json(d["morphism"], Vector{Trm})
+  )
+end
+
+function parse_json(d::Dict, ::Type{SimpleArena{T}}) where {T}
+  SimpleArena{T}(
+    parse_json(d["pos"], Context),
+    parse_json(d["dir"], Context)
+  )
+end
+
+function parse_json(d::Dict, L::Type{SimpleKleisliLens{T}}) where {T}
+  SimpleKleisliLens{T}(
+    parse_json(d["dom"], SimpleArena{T}),
+    parse_json(d["codom"], SimpleArena{T}),
+    parse_json(d["expose"], Vector{Trm}),
+    parse_json(d["update"], Vector{Trm})
+  )
+end
+
+end

--- a/src/stdlib/models/SimpleLenses.jl
+++ b/src/stdlib/models/SimpleLenses.jl
@@ -6,6 +6,8 @@ using ....Models
 using ....Syntax
 using ..ContextMaps
 
+using StructEquality
+
 module Impl
 
 using .....Syntax
@@ -13,9 +15,11 @@ using .....Models
 using ....StdTheories
 using ...ContextMaps
 
+using StructEquality
+
 const CM = ContextMaps.Impl
 
-struct Arena{T<:AbstractTheory}
+@struct_hash_equal struct Arena{T<:AbstractTheory}
   pos::Context
   dir::Context
 end
@@ -26,7 +30,7 @@ const Ob = Arena
 expose is a Kleisli map from codom.pos to dom.pos
 update is a Kleisli map from dom.dir to dom.pos + codom.dir
 """
-struct Lens{T<:AbstractTheory}
+@struct_hash_equal struct Lens{T<:AbstractTheory}
   expose::Vector{Trm}
   update::Vector{Trm}
 end
@@ -137,7 +141,7 @@ end
 
 end
 
-struct SimpleKleisliLens{T<:AbstractTheory} <: TypedHom{Impl.Arena{T}, Impl.Lens{T}}
+@struct_hash_equal struct SimpleKleisliLens{T<:AbstractTheory} <: TypedHom{Impl.Arena{T}, Impl.Lens{T}}
   dom::Impl.Arena{T}
   codom::Impl.Arena{T}
   morphism::Impl.Lens{T}

--- a/src/stdlib/module.jl
+++ b/src/stdlib/module.jl
@@ -4,8 +4,10 @@ using Reexport
 
 include("theories/module.jl")
 include("models/module.jl")
+include("Serialization.jl")
 
 @reexport using .StdTheories
 @reexport using .StdModels
+@reexport using .Serialization
 
 end

--- a/src/syntax/Theories.jl
+++ b/src/syntax/Theories.jl
@@ -7,7 +7,7 @@ using StructEquality
 
 using ...Util
 
-struct Lvl
+@struct_hash_equal struct Lvl
   val::UInt64
   function Lvl(i::Integer; context=false)
     i > 0 || error("Creating non-positive level $i context $context")
@@ -51,7 +51,7 @@ should point at a type constructor judgment.
 end
 
 
-struct Context 
+@struct_hash_equal struct Context
   ctx::Vector{Tuple{Name, Typ}}
   Context(c=Tuple{Name, Typ}[]) = new(c)
 end 

--- a/src/util/Names.jl
+++ b/src/util/Names.jl
@@ -1,6 +1,8 @@
 module Names
 export Name, StrLit, SymLit, Anon, Default
 
+using StructEquality
+
 """
 Names are used to label parts of a GAT.
 
@@ -9,7 +11,7 @@ internally.
 """
 abstract type Name end
 
-struct StrLit <: Name
+@struct_hash_equal struct StrLit <: Name
   name::String
 end
 
@@ -17,7 +19,7 @@ end
 We have a symbol wrapper because we get symbols from parsing, and it
 is faster to compare symbols than it is to compare strings.
 """
-struct SymLit <: Name
+@struct_hash_equal struct SymLit <: Name
   name::Symbol
 end
 
@@ -27,7 +29,7 @@ Name(n::Symbol) = n == :default ? Default() : SymLit(n)
 Name(n::Name) = n
 Name(i::Int)= SymLit(Symbol(i))
 
-struct Anon <: Name
+@struct_hash_equal struct Anon <: Name
 end
 
 Base.string(n::StrLit) = n.name
@@ -36,7 +38,7 @@ Base.string(::Anon) = "_"
 
 Base.show(n::SymLit) = string(n)
 
-struct Default <: Name
+@struct_hash_equal struct Default <: Name
 end
 
 Base.string(::Default) = "_"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 Gatlab = "f0ffcf3b-d13a-433e-917c-cc44ccf5ead2"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 StructEquality = "6ec83bb0-ed9f-11e9-3b4c-2b04cb4e219c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/stdlib/Serialization.jl
+++ b/test/stdlib/Serialization.jl
@@ -4,6 +4,19 @@ using Test
 
 using Gatlab
 
+periodic_params = @lens ThRing begin
+  dom = [β, γ] | [dβ, dγ]
+  codom = [β, γ] | [β₀, kᵦ, γ₀, kᵧ]
+  expose = begin
+    β = β
+    γ = γ
+  end
+  update = begin
+    dβ = -kᵦ*(β + (-β₀))
+    dγ = -kᵧ*(γ + (-γ₀))
+  end
+end
 
+@test parse_json(JSON.parse(JSON.json(periodic_params)), SimpleKleisliLens{ThRing}) == periodic_params
 
 end

--- a/test/stdlib/Serialization.jl
+++ b/test/stdlib/Serialization.jl
@@ -1,0 +1,9 @@
+module TestSerialization
+
+using Test
+
+using Gatlab
+
+
+
+end

--- a/test/stdlib/Serialization.jl
+++ b/test/stdlib/Serialization.jl
@@ -17,6 +17,11 @@ periodic_params = @lens ThRing begin
   end
 end
 
-@test parse_json(JSON.parse(JSON.json(periodic_params)), SimpleKleisliLens{ThRing}) == periodic_params
+rehydrated = parse_json(JSON.parse(JSON.json(periodic_params)), SimpleKleisliLens{ThRing})
+
+@test rehydrated.dom == periodic_params.dom
+@test rehydrated.codom == periodic_params.codom
+@test rehydrated.morphism == periodic_params.morphism
+@test rehydrated == periodic_params
 
 end

--- a/test/stdlib/Serialization.jl
+++ b/test/stdlib/Serialization.jl
@@ -1,8 +1,8 @@
 module TestSerialization
 
 using Test
-
 using Gatlab
+import JSON
 
 periodic_params = @lens ThRing begin
   dom = [β, γ] | [dβ, dγ]

--- a/test/stdlib/tests.jl
+++ b/test/stdlib/tests.jl
@@ -3,6 +3,7 @@ module TestTheories
 include("StdTheories.jl")
 include("ContextMaps.jl")
 include("Lenses.jl")
+include("Serialization.jl")
 
 
 end # module 


### PR DESCRIPTION
This also adds serialization for everything AlgebraicLenses depends on. However, this approach to serialization is perhaps not as general as I might like; it will do for the demo though.