### PR TITLE
fix presentation parser

### DIFF
--- a/src/syntax/Presentations.jl
+++ b/src/syntax/Presentations.jl
@@ -58,17 +58,11 @@ compose(f, g) == h == h′
 function ExprInterop.fromexpr(ctx::Context, e, ::Type{Presentation})
   e.head == :block || error("expected a block to parse into a GATSegment, got: $e")
   scopelines, eqlines = [], Vector{Expr0}[]
-  for line in e.args
-    if line isa LineNumberNode
-      push!(scopelines, line)
-    elseif line.head == :(==)
-      push!(eqlines, line.args)
-    elseif line.head == :comparison
-      er = "Bad comparison: $line"
-      all(((i,v),)-> iseven(i) == (v == :(==)), enumerate(line.args)) || error(er)
-      push!(eqlines, line.args[1:2:end])
-    else
-      push!(scopelines, line)
+  for line in filter(x->!(x isa LineNumberNode), e.args)
+    @match line begin
+      Expr(:call, :(==), a, b) => push!(eqlines, [a, b])
+      Expr(:comparison, xs...) => push!(eqlines, xs[1:2:end])
+      _ => push!(scopelines, line)
     end
   end
   scope = GATs.parsetypescope(ctx, scopelines)

--- a/test/syntax/Presentations.jl
+++ b/test/syntax/Presentations.jl
@@ -9,8 +9,8 @@ tscope = parsetypescope(
   T, 
   :([(a,b,c)::Ob, f::Hom(a,b), g::Hom(b,c), (h,h′)::Hom(a,c)]).args
 )
-_,_,_,f,g,h,h′ = idents(tscope)
-h,h′ = AlgTerm.([h,h′])
+_, _, _, f, g, h, h′ = idents(tscope)
+h, h′ = AlgTerm.([h,h′])
 fg = fromexpr(AppendScope(T, tscope), :(compose(f,g)), AlgTerm)
 p1 = Presentation(T, tscope, [[fg, h]])
 x1 = toexpr(p1)
@@ -50,5 +50,12 @@ t = fromexpr(Z, :(i(a) ⋅ (2::default)), AlgTerm)
 a = ident(Z; name=:a)
 
 @test compile(ThGroup, Dict(Reference(a) => :a), t) == :($(ThGroup).:(⋅)($(ThGroup).i(a), 2))
+
+@present D₄(ThGroup) begin
+  (r,f) :: default
+
+  (f⋅f) == e 
+  (r⋅r⋅r⋅r) == e
+end
 
 end # module 


### PR DESCRIPTION
Ignore LineNumberNodes when parsing presentation. Addresses https://github.com/AlgebraicJulia/GATlab.jl/issues/94