### PR TITLE
Theory Morphisms

### DIFF
--- a/src/stdlib/models/GATs.jl
+++ b/src/stdlib/models/GATs.jl
@@ -1,0 +1,20 @@
+module GATs
+export GATC
+
+using ....Models
+using ....Syntax
+using ...StdTheories
+
+using GATlab, GATlab.Models
+
+struct GATC <: Model{Tuple{GAT, AbsTheoryMap}}
+end
+
+@instance ThCategory{GAT, AbsTheoryMap} (;model::GATC) begin
+  id(x::GAT) = IdTheoryMap(x)
+  compose(f::AbsTheoryMap, g::AbsTheoryMap) = TheoryMaps.compose(f,g)
+  dom(f::AbsTheoryMap) = TheoryMaps.dom(f)
+  codom(f::AbsTheoryMap) = TheoryMaps.codom(f)
+end
+
+end # module

--- a/src/stdlib/models/module.jl
+++ b/src/stdlib/models/module.jl
@@ -7,11 +7,13 @@ include("FinMatrices.jl")
 include("SliceCategories.jl")
 include("Nothings.jl")
 include("ScopeTrees.jl")
+include("GATs.jl")
 
 @reexport using .FinSets
 @reexport using .FinMatrices
 @reexport using .SliceCategories
 @reexport using .Nothings
 @reexport using .ScopeTrees
+@reexport using .GATs
 
 end

--- a/src/stdlib/module.jl
+++ b/src/stdlib/module.jl
@@ -4,8 +4,10 @@ using Reexport
 
 include("theories/module.jl")
 include("models/module.jl")
+include("theorymaps/module.jl")
 
 @reexport using .StdTheories
 @reexport using .StdModels
+@reexport using .StdTheoryMaps
 
 end

--- a/src/stdlib/theories/Algebra.jl
+++ b/src/stdlib/theories/Algebra.jl
@@ -1,6 +1,6 @@
 module Algebra
 export ThSet, ThMagma, ThSemiGroup, ThMonoid, ThGroup, ThCMonoid, ThAb, ThRing,
-  ThCRing, ThRig, ThCRig, ThElementary
+  ThCRing, ThRig, ThCRig, ThElementary, ThPreorder
 
 using ....Syntax
 
@@ -64,5 +64,13 @@ end
 #   exp(x) ⊣ [x]
 #   sigmoid(x) ⊣ [x]
 # end
+
+@theory ThPreorder <: ThSet begin
+  Leq(dom, codom)::TYPE
+  @op (≤) := Leq
+  refl(p)::Leq(p,p)
+  trans(f::Leq(p,q),g::Leq(q,r))::Leq(p,r)  ⊣ [p,q,r]
+  irrev := f == g ::Leq(p,q) ⊣ [p,q, (f,g)::Leq(p,q)]
+end
 
 end

--- a/src/stdlib/theories/Naturals.jl
+++ b/src/stdlib/theories/Naturals.jl
@@ -8,7 +8,7 @@ using ....Syntax
 @theory ThNat begin
   ℕ :: TYPE
   Z :: ℕ
-  S(n::ℕ) ::  ℕ
+  S(n::ℕ) :: ℕ
 end
 
 @theory ThNatPlus <: ThNat begin
@@ -20,26 +20,5 @@ end
   ((x::ℕ) * (y::ℕ))::ℕ
   (n * S(m) == ((n * m) + n) :: ℕ) ⊣ [n::ℕ,m::ℕ]
 end
-
-"""
-@instance NatPlusIsMonoid{ThMonoid, ThNatPlus}
-  Ob = ℕ
-  x ∘ y = x + y
-  e() = Z()
-end
-
-@instance Swap{ThMonoid,ThMonoid}
-  Ob = Ob
-  ∘(x, y) = y ∘ x
-  e() = e()
-end
-
-@instance CatIsPreorder{ThCategory,ThPreorder}
-  Ob = Ob
-  Hom = Leq
-  ⋅(a,b) = trans(a,b)
-  id(a) = refl(a)
-end
-"""
 
 end

--- a/src/stdlib/theorymaps/Maps.jl
+++ b/src/stdlib/theorymaps/Maps.jl
@@ -1,0 +1,36 @@
+module Maps
+
+export SwapMonoid, NatPlusMonoid, PreorderCat
+
+using ...StdTheories
+using ....Syntax
+
+
+SwapMonoid = @theorymap ThMonoid => ThMonoid begin
+  default => default
+  x⋅y ⊣ [x, y] => y⋅x ⊣ [x,y]
+  e => e
+end
+
+
+NatPlusMonoid = @theorymap ThMonoid => ThNatPlus  begin
+  default => ℕ 
+  e => Z
+  (x ⋅ y) ⊣ [x, y] => x+y ⊣ [(x, y)::ℕ]
+end
+
+"""Preorders are categories"""
+PreorderCat = @theorymap ThCategory => ThPreorder begin
+  Ob => default
+  Hom => Leq
+  compose(f, g) ⊣ [a::Ob, b::Ob, c::Ob, f::(a → b), g::(b → c)] => 
+    trans(f, g) ⊣ [a, b, c, f::Leq(a, b), g::Leq(b, c)]  
+  id(a) ⊣ [a::Ob] => refl(a) ⊣ [a]
+end
+
+"""Thin categories are isomorphic to preorders"""
+# PreorderThinCat = compose(PreorderCat, Incl(ThCategory, ThThinCategory))
+# ThinCatPreorder = inv(PreorderThinCat)
+
+
+end # module

--- a/src/stdlib/theorymaps/module.jl
+++ b/src/stdlib/theorymaps/module.jl
@@ -1,0 +1,9 @@
+module StdTheoryMaps
+
+using Reexport
+
+include("Maps.jl") # split into files when big enough
+
+@reexport using .Maps
+
+end

--- a/src/syntax/ExprInterop.jl
+++ b/src/syntax/ExprInterop.jl
@@ -22,8 +22,9 @@ Converts a Julia Expr into type T, in a certain scope.
 """
 function fromexpr end
 
-function toexpr(c::Context, x::Ident)
+function toexpr(c::Context, x::Ident; showing=false)
   if !hasident(c, x)
+    showing || error("Unknown ident $x in context $c")
     return x
   end
   tag_level = getlevel(c, gettag(x))
@@ -68,11 +69,11 @@ function fromexpr(c::Context, e, ::Type{Ident}; sig=nothing)
   end
 end
 
-function reftolist(c::Context, ref::Reference)
+function reftolist(c::Context, ref::Reference; kw...)
   symbols = []
   while !isempty(ref)
     x = first(ref)
-    push!(symbols, toexpr(c, x))
+    push!(symbols, toexpr(c, x; kw...))
     ref = rest(ref)
     if !isempty(ref)
       c = getvalue(c, x)
@@ -81,8 +82,8 @@ function reftolist(c::Context, ref::Reference)
   symbols
 end
 
-function toexpr(c::Context, ref::Reference)
-  symbols = reftolist(c, ref)
+function toexpr(c::Context, ref::Reference; kw...)
+  symbols = reftolist(c, ref; kw...)
   if isempty(symbols)
     :(_)
   else

--- a/src/syntax/GATs.jl
+++ b/src/syntax/GATs.jl
@@ -110,7 +110,7 @@ headof(t::TrmTyp) = t.head
 argsof(t::TrmTyp) = t.args
 
 rename(tag::ScopeTag, reps::Dict{Symbol,Symbol}, t::T) where T<:TrmTyp =
-  T(rename(tag, reps, headof(t)), rename.(Ref(tag), Ref(reps), argsof(t)))
+  T(rename(tag, reps, headof(t)), AlgTerm[rename.(Ref(tag), Ref(reps), argsof(t))...])
 
 function Base.show(io::IO, type::T) where T<:TrmTyp
   print(io, "$(nameof(T))(")
@@ -256,11 +256,6 @@ sortsignature(tc::Union{AlgTypeConstructor, AlgTermConstructor}) =
 """Local context of an AlgTermConstructor, including the arguments themselves"""
 argcontext(t::Union{AlgTypeConstructor,AlgTermConstructor}) = 
   t.localcontext + t.args
-
-function retag_args(t::AlgTermConstructor) 
-  ac = gettag(argcontext(t))
-  Dict(gettag(t.localcontext)=>ac, gettag(t.args)=>ac)
-end
 
 """
 `AlgAxiom`
@@ -735,11 +730,6 @@ end
 
 ExprInterop.toexpr(c::Context, ts::TypeScope) =
   Expr(:vect,[Expr(:(::), nameof(b), toexpr(c, getvalue(b))) for b in ts]...)
-
-ExprInterop.fromexpr(c::Context, e, ::Type{TypeScope}) = @match e begin 
-  Expr(:vect, ps...) => parsetypescope(c, ps)
-  _ => error("Here $e $(dump(e))")
-end
 
 ExprInterop.toexpr(c::Context, at::Binding{AlgType, Nothing}) =
   Expr(:(::), nameof(at), ExprInterop.toexpr(c, getvalue(at)))

--- a/src/syntax/Scopes.jl
+++ b/src/syntax/Scopes.jl
@@ -467,20 +467,6 @@ retag(replacements::Dict{ScopeTag,ScopeTag}, s::Scope{T,Sig}) where {T,Sig} =
                retag.(Ref(replacements), s.bindings), 
                s.names)
 
-function rename(tag::ScopeTag, 
-                replacements::Dict{Symbol, Symbol}, 
-                scope::Scope{T, Sig}) where {T, Sig}
-  if tag == gettag(scope)
-    Scope{T,Sig}(tag, map(scope.bindings) do b
-      Binding{T,Sig}(get(replacements,b.primary,b.primary), 
-              Set([get(replacements, a, a) for a in b.aliases]), 
-              rename(tag, replacements, b.value), b.sig, b.line)
-    end, Dict(get(replacements, k, k)=>v for (k,v) in collect(scope.names)))
-  else 
-    Scope{T,Sig}(tag, retag(Ref(replacements), ))
-  end
-end
-
 function Base.:(+)(x::Scope{T,Sig}, y::Scope{T,Sig}) where {T,Sig}
   newtag = x.tag+y.tag
   rep = Dict(gettag(x) => newtag, gettag(y)=>newtag)

--- a/src/syntax/TheoryMaps.jl
+++ b/src/syntax/TheoryMaps.jl
@@ -22,29 +22,22 @@ thought of in many ways.
 3. X is a syntax for Y's semantics. 
 
 The main methods for an AbsTheoryMap to implement are: 
-  dom, codom, typemap, termmap
+  - dom, codom, 
+  - typemap: A dictionary of Ident (of AlgTypeConstructor in domain) to AlgSort
+             (This must be a AlgSort of the same arity.) 
+  - termmap: A dictionary of Ident (of AlgTermConstructor in domain) to 
+             TermInCtx. (The TypeScope of the TrmInCtx must be structurally 
+             identical to the localcontext + args of the term constructor 
+             associated with the key.)
+  
 """
 abstract type AbsTheoryMap end
 
-"""
-A dictionary of Ident (of AlgTypeConstructor in domain) to AlgSort
-
-This must be a AlgSort of the same arity.
-"""
-typemap(::AbsTheoryMap)::Dict{Ident, AlgSort} = error("Not implemented")
-
-"""
-A dictionary of Ident (of AlgTermConstructor in domain) to TermInCtx.
-The TypeScope of the TrmInCtx must be structurally identical to the 
-localcontext + args of the term constructor associated with the key.
-"""
-termmap(::AbsTheoryMap)::Dict{Ident, TermInCtx} = error("Not implemented")
-
 # Category of GATs
 #-----------------
-dom(f::AbsTheoryMap)::GAT = f.dom
+dom(f::AbsTheoryMap)::GAT = f.dom # assume this exists by default
 
-codom(f::AbsTheoryMap)::GAT = f.codom
+codom(f::AbsTheoryMap)::GAT = f.codom # assume this exists by default
 
 function compose(f::AbsTheoryMap, g::AbsTheoryMap)
   typmap = Dict(k => typemap(g)[only(v.ref)] for (k,v) in pairs(typemap(f)))
@@ -127,6 +120,8 @@ end
 dom(f::IdTheoryMap)::GAT = f.gat
 
 codom(f::IdTheoryMap)::GAT = f.gat
+
+compose(f::IdTheoryMap, ::IdTheoryMap) = f
 
 compose(::IdTheoryMap, g::AbsTheoryMap) = g
 
@@ -240,7 +235,6 @@ end
 
 macro theorymap(head, body)
   (domname, codomname) = @match head begin
-    (name::Symbol) => (name, nothing)
     Expr(:call,:(=>), name, parent) => (name, parent)
     _ => error("could not parse head of @theory: $head")
   end
@@ -251,6 +245,6 @@ macro theorymap(head, body)
 end
 
 """Invert a theory iso"""
-Base.inv(::TheoryMap) = error("Not implemented")
+# Base.inv(::TheoryMap) = error("Not implemented")
 
 end # module

--- a/src/syntax/TheoryMaps.jl
+++ b/src/syntax/TheoryMaps.jl
@@ -1,0 +1,256 @@
+module TheoryMaps
+export IdTheoryMap, TheoryIncl, AbsTheoryMap, TheoryMap, @theorymap,
+       TypeMap, TermMap, typemap, termmap
+
+using ..GATs, ..Scopes, ..ExprInterop
+using ..Scopes: unsafe_pushbinding!
+using ..GATs: bindingexprs, bind_localctx, substitute_term
+
+import ..ExprInterop: toexpr, fromexpr
+
+using StructEquality, MLStyle
+
+# Theory Maps
+#############
+
+"""
+TheoryMaps are morphisms in a category of GATs. A TheoryMap X -> Y can be 
+thought of in many ways.
+
+1. An "Every model of Y is also a model of X in some way"
+2. Providing "X-shaped hooks" into Y.
+3. X is a syntax for Y's semantics. 
+
+The main methods for an AbsTheoryMap to implement are: 
+  dom, codom, typemap, termmap
+"""
+abstract type AbsTheoryMap end
+
+"""
+A dictionary of Ident (of AlgTypeConstructor in domain) to AlgSort
+
+This must be a AlgSort of the same arity.
+"""
+typemap(::AbsTheoryMap)::Dict{Ident, AlgSort} = error("Not implemented")
+
+"""
+A dictionary of Ident (of AlgTermConstructor in domain) to TermInCtx.
+The TypeScope of the TrmInCtx must be structurally identical to the 
+localcontext + args of the term constructor associated with the key.
+"""
+termmap(::AbsTheoryMap)::Dict{Ident, TermInCtx} = error("Not implemented")
+
+# Category of GATs
+#-----------------
+dom(f::AbsTheoryMap)::GAT = f.dom
+
+codom(f::AbsTheoryMap)::GAT = f.codom
+
+function compose(f::AbsTheoryMap, g::AbsTheoryMap)
+  typmap = Dict(k => typemap(g)[only(v.ref)] for (k,v) in pairs(typemap(f)))
+  trmmap = Dict(k => g(v) for (k, v) in pairs(termmap(f)))
+  TheoryMap(dom(f), codom(g), typmap, trmmap)
+end
+
+function (t::AbsTheoryMap)(s::Ident) 
+  if haskey(typemap(t), s)
+    typemap(t)[s] 
+  elseif haskey(termmap(t), s)
+    termmap(t)[s]
+  else 
+    throw(KeyError("Cannot find key $s"))
+  end
+end
+
+
+(f::AbsTheoryMap)(c::AlgTerm) =  f(TermInCtx(c))
+
+"""Map a context in the domain theory into a context of the codomain theory"""
+function (f::AbsTheoryMap)(ctx::TypeScope) 
+  scope = TypeScope()
+  cache = Dict{Symbol, AlgTerm}()
+  for b in ctx
+    argnames = nameof.(only.(headof.(b.value.args)))
+    val = AlgType(f(only(b.value.head)).ref, AlgTerm[cache[a] for a in argnames])
+    new_binding = Binding{AlgType, Nothing}(b.primary, b.aliases, val, b.sig)
+    cache[nameof(b)] = AlgTerm(Ident(gettag(scope), LID(length(scope)+1), 
+                               nameof(new_binding)))
+    unsafe_pushbinding!(scope, new_binding)
+  end
+  scope
+end
+
+function (f::AbsTheoryMap)(t::TermInCtx)
+  fctx = f(t.ctx)
+  TermInCtx(fctx, f(t.ctx, t.trm, fctx))
+end
+
+""" Map a term `t` in context `c` along `f`. """
+function (f::AbsTheoryMap)(ctx::TypeScope, t::AlgTerm, fctx=nothing)::AlgTerm
+  fctx = isnothing(fctx) ? f(ctx) : fctx
+  head = only(headof(t))
+  if hasident(ctx, head)
+    retag(Dict(gettag(ctx)=>gettag(fctx)), t) # term is already in the context
+  else 
+    termcon = getvalue(f.dom[head]) # Toplevel TermConstructor of t in domain
+    new_term = f(head) # Codom TermInCtx associated with the toplevel termcon
+
+    # idents in bind_localctx refer to term constructors args and l.c.
+    rt_dict = Dict(gettag(x)=>gettag(new_term.ctx) 
+                   for x in [termcon.args, termcon.localcontext])
+
+    # new_term has same context as termcon, so recursively map over components
+    lc = bind_localctx(f.dom, TermInCtx(ctx,t))
+    flc = Dict(retag(rt_dict, k) => f(ctx, v, fctx) for (k, v) in pairs(lc))
+
+    substitute_term(new_term.trm, flc)
+  end
+end
+
+function toexpr(m::AbsTheoryMap)
+  typs = map(collect(typemap(m))) do (k, v)
+    Expr(:call, :(=>), toexpr(dom(m), k), toexpr(codom(m), v)) 
+  end       
+  trms = map(collect(termmap(m))) do (k,v)
+    domterm = toexpr(dom(m), TermInCtx(dom(m), k))
+    Expr(:call, :(=>), domterm, toexpr(codom(m), v)) 
+  end
+  Expr(:block, typs...,trms...)
+end
+
+# ID 
+#---
+@struct_hash_equal struct IdTheoryMap <: AbsTheoryMap
+  gat::GAT
+end
+
+dom(f::IdTheoryMap)::GAT = f.gat
+
+codom(f::IdTheoryMap)::GAT = f.gat
+
+compose(::IdTheoryMap, g::AbsTheoryMap) = g
+
+compose(f::AbsTheoryMap, ::IdTheoryMap) = f
+
+"""Invert a theory iso"""
+Base.inv(f::IdTheoryMap) = f
+
+
+# Inclusion 
+#----------
+"""
+A theory inclusion has a subset of scopes 
+"""
+@struct_hash_equal struct TheoryIncl <: AbsTheoryMap
+  dom::GAT
+  codom::GAT
+  function TheoryIncl(dom,codom) 
+    err = "Cannot construct TheoryInclusion"
+    dom ⊆ codom ? new(dom,codom) : error(err)
+  end
+end
+
+typemap(ι::Union{IdTheoryMap,TheoryIncl}) = 
+  Dict(k => AlgSort(k) for k in typecons(dom(ι)))
+
+termmap(ι::Union{IdTheoryMap,TheoryIncl}) = 
+  Dict(k=>TermInCtx(dom(ι), k) for k in termcons(dom(ι)))
+
+compose(f::TheoryIncl, g::TheoryIncl) = TheoryIncl(dom(f), codom(g))
+
+compose(f::AbsTheoryMap, g::TheoryIncl) = 
+  TheoryIncl(dom(f), codom(g), typemap(f), termmap(f))
+
+Base.inv(f::TheoryIncl) = 
+  dom(f) == codom(f) ? f : error("Cannot invert a nontrivial theory inclusion")
+
+# Non-inclusion 
+#--------------
+
+"""
+Presently, axioms are not mapped to proofs.
+
+TODO: check that it is well-formed, axioms are preserved.
+"""
+@struct_hash_equal struct TheoryMap <: AbsTheoryMap
+  dom::GAT
+  codom::GAT
+  typemap::Dict{Ident,AlgSort}
+  termmap::Dict{Ident,TermInCtx}
+  function TheoryMap(dom, codom, typmap, trmmap)
+    missing_types = setdiff(Set(keys(typmap)), Set(typecons(dom))) 
+    missing_terms = setdiff(Set(keys(trmmap)), Set(termcons(dom))) 
+    isempty(missing_types) || error("Missing types $missing_types")
+    isempty(missing_terms) || error("Missing types $missing_terms")
+    f = new(dom, codom, typmap, trmmap)
+
+    # Check type constructors are coherent
+    for (k, v) in pairs(typmap)
+      f_args = f(argcontext(getvalue(dom[k])))
+      arg_fs = argcontext(getvalue(codom[only(v.ref)]))
+      err = "Bad type map $k => $v ($f_args != $arg_fs)"
+      Scopes.equiv(f_args, arg_fs) || error(err)
+    end
+    # Check term constructors are coherent
+    for (k, v) in pairs(trmmap)
+      f_args = f(argcontext(getvalue(dom[k])))
+      arg_fs = v.ctx
+      err = "Bad term map $k => $v ($f_args != $arg_fs)"
+      Scopes.equiv(f_args, arg_fs) || error(err)
+    end
+
+    f
+  end
+end
+
+typemap(t::TheoryMap) = t.typemap
+
+termmap(t::TheoryMap) = t.termmap
+
+"""
+TODO: we currently ignore LineNumberNodes. TheoryMap data structure could 
+      instead use scopes (rather than Dicts) which store this info in Bindings.
+
+TODO: handle more ambiguity via type inference
+"""
+function fromexpr(dom::GAT, codom::GAT, e, ::Type{TheoryMap})
+  tyms, trms = Dict{Ident, AlgSort}(), Dict{Ident, TermInCtx}()
+  exprs = @match e begin
+    Expr(:block, e1::Expr, es...) => [e1,es...]
+    Expr(:block, ::LineNumberNode, es...) => filter(x->!(x isa LineNumberNode), es)
+  end
+  for expr in exprs
+    e1, e2 = @match expr begin Expr(:call, :(=>), e1, e2) => (e1,e2) end
+    if e1 ∈ nameof.(typecons(dom))
+      tyms[fromexpr(dom, e1, Ident)] = fromexpr(codom, e2, AlgSort)
+    else
+      val = fromexpr(codom, e2, TermInCtx)
+      key = fromexpr(dom, e1, TermInCtx)
+
+      # Check that dom ctx is the same (modulo retagging) with term argcontext
+      khead = only(key.trm.head)
+      a_c = argcontext(getvalue(dom[khead]))
+      Scopes.equiv(key.ctx, a_c) || error("CONTEXT ERROR\n$(key.ctx)\n$a_c")
+
+      trms[khead] = val
+    end
+  end
+  TheoryMap(dom, codom, tyms, trms)
+end
+
+macro theorymap(head, body)
+  (domname, codomname) = @match head begin
+    (name::Symbol) => (name, nothing)
+    Expr(:call,:(=>), name, parent) => (name, parent)
+    _ => error("could not parse head of @theory: $head")
+  end
+
+  dom = macroexpand(__module__, :($domname.@theory))
+  codom = macroexpand(__module__, :($codomname.@theory))
+  fromexpr(dom, codom, body, TheoryMap)
+end
+
+"""Invert a theory iso"""
+Base.inv(::TheoryMap) = error("Not implemented")
+
+end # module

--- a/src/syntax/module.jl
+++ b/src/syntax/module.jl
@@ -7,11 +7,13 @@ include("ExprInterop.jl")
 include("GATs.jl")
 include("Presentations.jl")
 include("TheoryInterface.jl")
+include("TheoryMaps.jl")
 
 @reexport using .Scopes
 @reexport using .ExprInterop
 @reexport using .GATs
 @reexport using .Presentations
 @reexport using .TheoryInterface
+@reexport using .TheoryMaps
 
 end

--- a/test/stdlib/models/GATs.jl
+++ b/test/stdlib/models/GATs.jl
@@ -1,0 +1,22 @@
+module TestGATs
+
+using GATlab, Test
+using .ThCategory
+
+@withmodel GATC() (Ob, Hom, id, compose, dom, codom) begin
+
+  codom(SwapMonoid) == dom(NatPlusMonoid)
+
+  x = toexpr(compose(id(ThMonoid.THEORY), compose(SwapMonoid, NatPlusMonoid)))
+
+  expected = @theorymap ThMonoid => ThNatPlus begin
+    default => ℕ
+    x ⋅ y ⊣ [x, y] => y + x ⊣ [x::ℕ, y::ℕ]
+    e => Z
+  end
+
+  @test x == toexpr(expected)
+
+end
+
+end # module

--- a/test/stdlib/models/tests.jl
+++ b/test/stdlib/models/tests.jl
@@ -5,5 +5,6 @@ include("FinMatrices.jl")
 include("SliceCategories.jl")
 include("Nothings.jl")
 include("ScopeTrees.jl")
+include("GATs.jl")
 
 end

--- a/test/syntax/GATs.jl
+++ b/test/syntax/GATs.jl
@@ -24,7 +24,7 @@ three = AlgTerm(plus, [one, two])
 @test fromexpr(EmptyContext(), two.head, AlgTerm) == two
 @test_throws Exception fromexpr(EmptyContext(), :(x = 3), AlgTerm)
 
-@test basicprinted(two) == "AlgTerm(:(2::number))"
+@test basicprinted(two) == "AlgTerm(2::number)"
 
 @test_throws Exception AlgSort(scope, three)
 
@@ -77,5 +77,24 @@ haa = AlgType(H,[AlgTerm(A),AlgTerm(A)])
 haia = AlgType(H,[AlgTerm(A),ida])
 @test sortcheck(ss, haa)
 @test_throws Exception sortcheck(ss, haia)
+
+# Subset 
+#-------
+T = ThCategory.THEORY
+TG = ThGraph.THEORY
+@test TG ⊆ T
+@test T ⊈ TG
+
+# TermInCtx
+#----------
+tic = fromexpr(T, :(compose(f,compose(id(b),id(b))) ⊣ [a::Ob, b::Ob, f::Hom(a,b)]), TermInCtx);
+tic2 = fromexpr(T,toexpr(T, tic),TermInCtx) # same modulo scope tags
+
+# Type inference 
+#---------------
+
+t = fromexpr(T,:(id(x)⋅(p⋅q) ⊣ [(x,y,z)::Ob, p::Hom(x,y), q::Hom(y,z)]), TermInCtx)
+expected = fromexpr(AppendScope(T, t.ctx), :(Hom(x,z)), AlgType)
+@test Syntax.GATs.infer_type(T, t) == expected
 
 end # module

--- a/test/syntax/GATs.jl
+++ b/test/syntax/GATs.jl
@@ -59,6 +59,8 @@ O, H, i, cmp = idents(seg; lid=LID.(1:4))
 # Extend seg with a context of (A: Ob)
 sortscope = Scope([Binding{AlgType}(:A, Set([:A]), AlgType(O))])
 A = ident(sortscope; name=:A)
+ATerm = AlgTerm(A)
+
 
 ss = AppendScope(ScopeList([seg]), sortscope)
 @test sortcheck(ss, AlgTerm(A)) == AlgSort(O)
@@ -77,6 +79,12 @@ haa = AlgType(H,[AlgTerm(A),AlgTerm(A)])
 haia = AlgType(H,[AlgTerm(A),ida])
 @test sortcheck(ss, haa)
 @test_throws Exception sortcheck(ss, haia)
+
+# Renaming 
+BTerm = rename(gettag(sortscope), Dict(:A=>:B), ATerm)
+Bsortscope = Scope([Binding{AlgType}(:B, Set([:B]), AlgType(O))]; tag=gettag(sortscope))
+BTerm_expected = AlgTerm(ident(Bsortscope;name=:B))
+@test BTerm == BTerm_expected
 
 # Subset 
 #-------

--- a/test/syntax/Scopes.jl
+++ b/test/syntax/Scopes.jl
@@ -5,6 +5,8 @@ using Test, GATlab
 # ScopeTags
 ###########
 
+basicprinted(x; color=false) = sprint(show, x; context=(:color=>color))
+
 tag1 = newscopetag()
 tag2 = newscopetag()
 
@@ -15,6 +17,9 @@ tag2 = newscopetag()
 err = ScopeTagError(nothing, nothing)
 
 @test sprint(showerror, err) isa String
+
+@test basicprinted(tag1) != basicprinted(tag2)
+@test basicprinted(tag1; color=true) != basicprinted(tag2)
 
 # Local IDs
 ###########
@@ -52,6 +57,8 @@ nameless = Ident(tag1, LID(1), nothing)
 
 # References
 ############
+@test_throws ArgumentError only(Reference())
+@test basicprinted(Reference()) == "_"
 
 y = Ident(tag2, LID(1), :y)
 xdoty = Reference(x, Reference(y))

--- a/test/syntax/TheoryMaps.jl
+++ b/test/syntax/TheoryMaps.jl
@@ -1,0 +1,76 @@
+module TestTheoryMaps 
+
+using GATlab
+using Test
+
+# Set up 
+########
+
+T = ThCategory.THEORY
+T2 = ThPreorder.THEORY
+
+# TheoryMaps 
+############
+x = toexpr(PreorderCat);
+tm2 = fromexpr(T, T2, x, TheoryMap)
+x2 = toexpr(tm2)
+@test x == x2
+
+# Validation of putative theory maps 
+#-----------------------------------
+@test_throws LoadError @eval @theorymap ThCategory => ThPreorder begin
+  Ob => default
+  Hom => Leq
+  compose(f, g) ⊣ [(a,b,c,d)::Ob, f::(a → b), g::(c → d)] => 
+    trans(f, g) ⊣ [a,b,c,d, f::Leq(a, b), g::Leq(c, d)] # wrong ctx for compose
+  id(a) ⊣ [a::Ob] => refl(a) ⊣ [a]
+end
+
+@test_throws LoadError @eval @theorymap ThCategory => ThPreorder begin
+  Ob => default
+  Hom => Leq
+  compose(f, g) ⊣ [(a,b,c)::Ob, f::(a → b), g::(b → c)] => 
+    trans(f, g) ⊣ [a, b, c, f::Leq(a, b), g::Leq(b, c)]
+  id(a) ⊣ [a::Ob] => refl(a) ⊣ [a, b] # codom has different context
+end
+
+@test_throws LoadError @eval @theorymap ThCategory => ThPreorder begin
+  Ob => default
+  Hom => default # bad type map
+  compose(f, g) ⊣ [(a,b,c)::Ob, f::(a → b), g::(b → c)] => 
+    trans(f, g) ⊣ [a, b, c, f::Leq(a, b), g::Leq(b, c)]
+  id(a) ⊣ [a::Ob] => refl(a) ⊣ [a]
+end
+
+@test_throws LoadError @eval @theorymap ThCategory => ThPreorder begin
+  Ob => default
+  Hom => Leq
+  compose(f, g) ⊣ [a::Ob, b::Ob, c::Ob, f::(a → b), g::(b → c)] => 
+    trans(f, g) ⊣ [a, b, c, f::Leq(a, b), g::Leq(b, c)]  
+  id(b) ⊣ [b::Ob] => refl(a) ⊣ [a] # the LHS doesn't match id's originally defined context
+end
+
+# Applying theorymap as a function to Ident and TermInCtx
+#--------------------------------------------------------
+(Ob, Hom), (Cmp, Id) = typecons(T), termcons(T)
+@test PreorderCat(Ob) == AlgSort(ident(T2; name=:default))
+@test PreorderCat(Cmp) isa TermInCtx
+@test PreorderCat(argcontext(getvalue(T[Cmp]))) isa TypeScope
+
+xterm = fromexpr(ThMonoid.THEORY, :(x ⊣ [x]), TermInCtx)
+res = NatPlusMonoid(xterm)
+toexpr(ThNat.THEORY, res)
+
+xterm = fromexpr(ThMonoid.THEORY, :(e⋅(e⋅x) ⊣ [x]), TermInCtx)
+res = NatPlusMonoid(xterm)
+expected = fromexpr(ThNatPlus.THEORY, :(Z+(Z+x) ⊣ [x::ℕ]), TermInCtx)
+@test toexpr(ThNatPlus.THEORY, res) == toexpr(ThNatPlus.THEORY, expected)
+
+# Inclusions 
+#############
+TLC = ThLawlessCat.THEORY
+incl = TheoryIncl(TLC, T)
+toexpr(incl)
+@test_throws ErrorException TheoryIncl(T, TLC)
+
+end # module

--- a/test/syntax/TheoryMaps.jl
+++ b/test/syntax/TheoryMaps.jl
@@ -57,6 +57,8 @@ end
 @test PreorderCat(Cmp) isa TermInCtx
 @test PreorderCat(argcontext(getvalue(T[Cmp]))) isa TypeScope
 
+@test_throws KeyError PreorderCat(first(typecons(T2)))
+
 xterm = fromexpr(ThMonoid.THEORY, :(x ⊣ [x]), TermInCtx)
 res = NatPlusMonoid(xterm)
 toexpr(ThNat.THEORY, res)
@@ -70,7 +72,24 @@ expected = fromexpr(ThNatPlus.THEORY, :(Z+(Z+x) ⊣ [x::ℕ]), TermInCtx)
 #############
 TLC = ThLawlessCat.THEORY
 incl = TheoryIncl(TLC, T)
+@test TheoryMaps.dom(incl) == TLC
+@test TheoryMaps.codom(incl) == T
+incl2 = TheoryIncl(ThGraph.THEORY, TLC)
+incl3 = TheoryIncl(ThGraph.THEORY, T)
+
+@test TheoryMaps.compose(incl2, incl) == incl3
+
 toexpr(incl)
 @test_throws ErrorException TheoryIncl(T, TLC)
+@test_throws ErrorException inv(incl)
+
+# Identity 
+##########
+i = IdTheoryMap(T)
+@test TheoryMaps.dom(i) == T
+@test TheoryMaps.codom(i) == T
+@test TheoryMaps.compose(i,i) == i
+@test TheoryMaps.compose(incl,i) == incl
+
 
 end # module

--- a/test/syntax/tests.jl
+++ b/test/syntax/tests.jl
@@ -23,4 +23,9 @@ end
   include("TheoryInterface.jl")
 end
 
+@testset "TheoryMaps" begin
+  include("TheoryMaps.jl")
+end
+
+
 end


### PR DESCRIPTION
Some initial work for theory morphism support.

The key features now are `@theorymap` macro, the pushing forward of terms along theory morphisms and the model `GATC` (for `ThCategory`) of GATs and GAT morphisms.  Additionally the `stdlib` now has a file for standard theory morphisms, such as `swap: ThMonoid -> ThMonoid`, interpreting preorders as categories and interpreting the naturals + addition as a monoid. 

Pushing forward terms required a new struct `TermInCtx` for AlgTerms in a TypeScope as well as an implementation of type inference (`TermInCtx -> AlgType`). 