### PR TITLE
add import statements to @theory declaration

### DIFF
--- a/src/models/ModelInterface.jl
+++ b/src/models/ModelInterface.jl
@@ -193,7 +193,7 @@ function parse_model_param(e)
   model_type = @match paramdecl begin
     Expr(:vect, Expr(:(::), :model, model_type)) => model_type
     nothing => nothing
-    _ => error("invalid syntax for declaring model type: $model")
+    _ => error("invalid syntax for declaring model type: $paramdecl")
   end
 
   (model_type, whereparams)

--- a/src/stdlib/models/Arithmetic.jl
+++ b/src/stdlib/models/Arithmetic.jl
@@ -1,0 +1,16 @@
+module Arithmetic 
+
+export IntNatPlus
+
+using ....Models
+using ...StdTheories
+
+struct IntNatPlus <: Model{Tuple{Int}} end
+
+@instance ThNatPlus{Int} [model::IntNatPlus] begin
+  Z() = 0
+  S(n::Int) = n + 1
+  +(x::Int, y::Int) = x + y
+end
+
+end # module 

--- a/src/stdlib/models/module.jl
+++ b/src/stdlib/models/module.jl
@@ -3,6 +3,7 @@ module StdModels
 using Reexport
 
 include("FinSets.jl")
+include("Arithmetic.jl")
 include("FinMatrices.jl")
 include("SliceCategories.jl")
 include("Op.jl")
@@ -10,6 +11,7 @@ include("Nothings.jl")
 include("GATs.jl")
 
 @reexport using .FinSets
+@reexport using .Arithmetic
 @reexport using .FinMatrices
 @reexport using .SliceCategories
 @reexport using .Op

--- a/src/stdlib/theories/Naturals.jl
+++ b/src/stdlib/theories/Naturals.jl
@@ -12,6 +12,7 @@ using ....Syntax
 end
 
 @theory ThNatPlus <: ThNat begin
+  import Base: +
   ((x::ℕ) + (y::ℕ))::ℕ
   (n + S(m) == S(n+m) :: ℕ) ⊣ [n::ℕ,m::ℕ]
 end

--- a/src/syntax/TheoryInterface.jl
+++ b/src/syntax/TheoryInterface.jl
@@ -53,13 +53,23 @@ macro theory(head, body)
   end
 
   newsegment = fromexpr(parent, body, GATSegment)
+  importlines = Expr[]
+  for line in body.args
+    @switch line begin 
+      @case Expr(:import, Expr(:(:), Expr(:., mod), imports)) 
+        push!(importlines, line)
+      @case _ 
+        nothing 
+    end 
+  end
+
 
   theory = GAT(name, parent, newsegment)
 
   modulelines = Any[]
 
   push!(modulelines, :(export $(allnames(theory; aliases=true)...)))
-
+  append!(modulelines, importlines)
   if !isnothing(parentname)
     push!(modulelines, Expr(:using, Expr(:(.), :(.), :(.), parentname)))
   end

--- a/test/stdlib/models/Arithmetic.jl
+++ b/test/stdlib/models/Arithmetic.jl
@@ -1,0 +1,13 @@
+module TestArithmetic 
+
+using GATlab
+using Test
+
+using .ThNatPlus
+
+@withmodel IntNatPlus() (ℕ, Z, S, +) begin
+  @test S(S(Z())) + Z() == 2
+end
+
+
+end # module 

--- a/test/stdlib/models/tests.jl
+++ b/test/stdlib/models/tests.jl
@@ -1,6 +1,7 @@
 module TestStdModels
 
 include("FinSets.jl")
+include("Arithmetic.jl")
 include("FinMatrices.jl")
 include("SliceCategories.jl")
 include("Op.jl")


### PR DESCRIPTION
This allows us to explicitly declare that the generated methods in the associated theory module extend some other methods.