### PR TITLE
Theory maps send type constructors to general types in a context

### DIFF
--- a/src/stdlib/theorymaps/Maps.jl
+++ b/src/stdlib/theorymaps/Maps.jl
@@ -1,6 +1,6 @@
 module Maps
 
-export SwapMonoid, NatPlusMonoid, PreorderCat
+export SwapMonoid, NatPlusMonoid, PreorderCat, OpCat
 
 using ...StdTheories
 using ....Syntax
@@ -17,6 +17,15 @@ NatPlusMonoid = @theorymap ThMonoid => ThNatPlus  begin
   default => ℕ 
   e => Z
   (x ⋅ y) ⊣ [x, y] => x+y ⊣ [(x, y)::ℕ]
+end
+
+
+OpCat = @theorymap ThCategory => ThCategory begin
+  Ob => Ob
+  Hom => Hom(codom,dom) ⊣ [dom::Ob, codom::Ob]
+  compose(f, g) ⊣ [a::Ob, b::Ob, c::Ob, f::(a → b), g::(b → c)] => 
+    compose(g, f) ⊣ [a::Ob, b::Ob, c::Ob, f::(b → a), g::(c → b)]  
+  id(a) ⊣ [a::Ob] => id(a) ⊣ [a::Ob]
 end
 
 """Preorders are categories"""

--- a/test/syntax/GATs.jl
+++ b/test/syntax/GATs.jl
@@ -93,10 +93,14 @@ TG = ThGraph.THEORY
 @test TG ⊆ T
 @test T ⊈ TG
 
-# TermInCtx
+# InCtx
 #----------
 tic = fromexpr(T, :(compose(f,compose(id(b),id(b))) ⊣ [a::Ob, b::Ob, f::Hom(a,b)]), TermInCtx);
 tic2 = fromexpr(T,toexpr(T, tic),TermInCtx) # same modulo scope tags
+
+
+typic = fromexpr(T, :(Hom(a,b) ⊣ [a::Ob, b::Ob, f::Hom(a,b)]), TypeInCtx)
+typic2 = fromexpr(T,toexpr(T, typic), TypeInCtx) # same modulo scope tags
 
 # Type inference 
 #---------------

--- a/test/syntax/TheoryMaps.jl
+++ b/test/syntax/TheoryMaps.jl
@@ -52,9 +52,15 @@ end
 
 # Applying theorymap as a function to Ident and TermInCtx
 #--------------------------------------------------------
+
+# Test PreorderCat
+
 (Ob, Hom), (Cmp, Id) = typecons(T), termcons(T)
-@test PreorderCat(Ob) == AlgSort(ident(T2; name=:default))
+@test PreorderCat(Ob) == InCtx(T2, ident(T2; name=:default))
 @test PreorderCat(Cmp) isa TermInCtx
+
+PreorderCat(argcontext(getvalue(T[Cmp])))
+
 @test PreorderCat(argcontext(getvalue(T[Cmp]))) isa TypeScope
 
 @test_throws KeyError PreorderCat(first(typecons(T2)))
@@ -67,6 +73,13 @@ xterm = fromexpr(ThMonoid.THEORY, :(e⋅(e⋅x) ⊣ [x]), TermInCtx)
 res = NatPlusMonoid(xterm)
 expected = fromexpr(ThNatPlus.THEORY, :(Z+(Z+x) ⊣ [x::ℕ]), TermInCtx)
 @test toexpr(ThNatPlus.THEORY, res) == toexpr(ThNatPlus.THEORY, expected)
+
+# Test OpCat
+
+xterm = fromexpr(T, :(id(x) ⋅ p ⋅ q ⋅ id(z) ⊣ [(x,y,z)::Ob, p::Hom(x,y), q::Hom(y,z)]), TermInCtx)
+expected = :(compose(id(z), compose(q,  compose(p, id(x)))) ⊣ [x::Ob,y::Ob,z::Ob, p::Hom(y,x), q::Hom(z,y)])
+@test toexpr(T, OpCat(xterm)) == expected
+
 
 # Inclusions 
 #############


### PR DESCRIPTION
This removes an earlier restriction that sent AlgSorts to AlgSorts. 

This allows us to express the theory morphism `op: ThCategory -> ThCategory`. 