### PR TITLE
TypeCtx as generalization of TypeScope, better @theorymap parsing

### DIFF
--- a/src/models/SymbolicModels.jl
+++ b/src/models/SymbolicModels.jl
@@ -357,7 +357,7 @@ function internal_constructors(theory::GAT)::Vector{JuliaFunction}
     )
 
     check_or_error = Expr(:(||), :(!strict), check_expr, throw_expr)
-    exprs = [idents(termcon.args)..., idents(termcon.localcontext)...]
+    exprs = [getidents(termcon.args)..., getidents(termcon.localcontext)...]
     expr_lookup = Dict{Ident, Any}(map(exprs) do x 
       x => build_infer_expr(first(eqs[x]))
     end)

--- a/src/stdlib/models/module.jl
+++ b/src/stdlib/models/module.jl
@@ -8,7 +8,7 @@ include("FinMatrices.jl")
 include("SliceCategories.jl")
 include("Op.jl")
 include("Nothings.jl")
-# include("GATs.jl")
+include("GATs.jl")
 
 @reexport using .FinSets
 @reexport using .Arithmetic
@@ -16,6 +16,6 @@ include("Nothings.jl")
 @reexport using .SliceCategories
 @reexport using .Op
 @reexport using .Nothings
-# @reexport using .GATs
+@reexport using .GATs
 
 end

--- a/src/stdlib/module.jl
+++ b/src/stdlib/module.jl
@@ -4,10 +4,10 @@ using Reexport
 
 include("theories/module.jl")
 include("models/module.jl")
-# include("theorymaps/module.jl")
+include("theorymaps/module.jl")
 
 @reexport using .StdTheories
 @reexport using .StdModels
-# @reexport using .StdTheoryMaps
+@reexport using .StdTheoryMaps
 
 end

--- a/src/stdlib/theorymaps/Maps.jl
+++ b/src/stdlib/theorymaps/Maps.jl
@@ -5,7 +5,7 @@ export SwapMonoid, NatPlusMonoid, PreorderCat, OpCat
 using ...StdTheories
 using ....Syntax
 
-
+using GATlab
 SwapMonoid = @theorymap ThMonoid => ThMonoid begin
   default => default
   x⋅y ⊣ [x, y] => y⋅x
@@ -22,16 +22,16 @@ end
 
 OpCat = @theorymap ThCategory => ThCategory begin
   Ob => Ob
-  Hom(dom::Ob, codom::Ob) => Hom(codom, dom)
-  id(a::Ob) => id(a)
-  compose(f::Hom(a,b), g::Hom(b,c)) ⊣ [(a,b,c)::Ob] => compose(g, f)
+  Hom(dom, codom) ⊣ [dom::Ob, codom::Ob] => Hom(codom, dom)
+  id(a) ⊣ [a::Ob] => id(a)
+  compose(f,g) ⊣ [(a,b,c)::Ob, f::Hom(a,b), g::Hom(b,c)] => compose(g, f)
 end
 
 """Preorders are categories"""
 PreorderCat = @theorymap ThCategory => ThPreorder begin
   Ob => default
-  Hom(dom::Ob, codom::Ob) => Leq(dom, codom)
-  compose(f::(a → b), g::(b → c)) ⊣ [a::Ob, b::Ob, c::Ob] => trans(f, g)
+  Hom(dom, codom) ⊣ [dom::Ob, codom::Ob] => Leq(dom, codom)
+  compose(f, g) ⊣ [a::Ob, b::Ob, c::Ob, f::(a → b), g::(b → c)] => trans(f, g)
   id(a) ⊣ [a::Ob] => refl(a)
 end
 

--- a/src/stdlib/theorymaps/Maps.jl
+++ b/src/stdlib/theorymaps/Maps.jl
@@ -22,7 +22,7 @@ end
 
 OpCat = @theorymap ThCategory => ThCategory begin
   Ob => Ob
-  Hom(dom::Ob, codom::Ob) => Hom(codom,dom)
+  Hom(dom::Ob, codom::Ob) => Hom(codom, dom)
   id(a::Ob) => id(a)
   compose(f::Hom(a,b), g::Hom(b,c)) ⊣ [(a,b,c)::Ob] => compose(g, f)
 end

--- a/src/stdlib/theorymaps/Maps.jl
+++ b/src/stdlib/theorymaps/Maps.jl
@@ -8,7 +8,7 @@ using ....Syntax
 
 SwapMonoid = @theorymap ThMonoid => ThMonoid begin
   default => default
-  x⋅y ⊣ [x, y] => y⋅x ⊣ [x,y]
+  x⋅y ⊣ [x, y] => y⋅x
   e => e
 end
 
@@ -16,7 +16,7 @@ end
 NatPlusMonoid = @theorymap ThMonoid => ThNatPlus  begin
   default => ℕ 
   e => Z
-  (x ⋅ y) ⊣ [x, y] => x+y ⊣ [(x, y)::ℕ]
+  (x ⋅ y) ⊣ [x, y] => x+y
 end
 
 
@@ -30,10 +30,9 @@ end
 """Preorders are categories"""
 PreorderCat = @theorymap ThCategory => ThPreorder begin
   Ob => default
-  Hom => Leq
-  compose(f, g) ⊣ [a::Ob, b::Ob, c::Ob, f::(a → b), g::(b → c)] => 
-    trans(f, g) ⊣ [a, b, c, f::Leq(a, b), g::Leq(b, c)]  
-  id(a) ⊣ [a::Ob] => refl(a) ⊣ [a]
+  Hom(dom::Ob, codom::Ob) => Leq(dom, codom)
+  compose(f::(a → b), g::(b → c)) ⊣ [a::Ob, b::Ob, c::Ob] => trans(f, g)
+  id(a) ⊣ [a::Ob] => refl(a)
 end
 
 """Thin categories are isomorphic to preorders"""

--- a/src/syntax/GATs.jl
+++ b/src/syntax/GATs.jl
@@ -164,7 +164,6 @@ function fromexpr!(c::Context, e, bound::TypeScope, ::Type{AlgTerm}; constants=t
     end
     e::Expr => error("could not parse AlgTerm from $e")
     constant::Constant => AlgTerm(constant)
-    i::Ident => AlgTerm(i)
   end
 end
 

--- a/src/syntax/GATs.jl
+++ b/src/syntax/GATs.jl
@@ -640,10 +640,6 @@ toexpr(c::Context, constant::Constant; kw...) =
   Expr(:(::), constant.value, toexpr(c, constant.type; kw...))
 
 
-toexpr(c::Context, term::AlgSort; kw...) = toexpr(c, term.ref; kw...)
-
-fromexpr(c::Context, e, ::Type{AlgSort}) = AlgSort(fromexpr(c, e, Ident))
-
 function bindingexprs(c::Context, s::Scope)
   c′ = AppendScope(c, s)
   [Expr(:(::), nameof(b), toexpr(c′, getvalue(b))) for b in s]
@@ -784,9 +780,6 @@ end
 
 toexpr(c::Context, ts::TypeScope; kw...) =
   Expr(:vect,[Expr(:(::), nameof(b), toexpr(c, getvalue(b); kw...)) for b in ts]...)
-
-toexpr(c::Context, at::Binding{AlgType, Nothing}) =
-  Expr(:(::), nameof(at), toexpr(c, getvalue(at)))
 
 function fromexpr(c::Context, e, ::Type{JudgmentBinding})
   (binding, localcontext) = @match normalize_decl(e; axiom=true) begin

--- a/src/syntax/Presentations.jl
+++ b/src/syntax/Presentations.jl
@@ -11,7 +11,7 @@ A presentation has a set of generators, given by a `TypeScope`, and a set of
 equations among terms which can refer to those generators. Each element of 
 `eqs` is a list of terms which are asserted to be equal.
 """
-@struct_hash_equal struct Presentation <: HasContext
+@struct_hash_equal struct Presentation <: HasContext{AlgType, Nothing}
   theory::GAT
   scope::TypeScope
   eqs::Vector{Vector{AlgTerm}}

--- a/src/syntax/Scopes.jl
+++ b/src/syntax/Scopes.jl
@@ -397,9 +397,6 @@ Base.:(==)(s1::Scope, s2::Scope) = s1.tag == s2.tag
 
 Base.hash(s::Scope, h::UInt64) = hash(s.tag, h)
 
-"""Compare two scopes, ignoring the difference in the top-level scope tag."""
-equiv(s1::Scope, s2::Scope) = s1.bindings == retag(Dict(s2.tag => s1.tag), s2).bindings
-
 Scope{T, Sig}() where {T, Sig} = 
   Scope{T, Sig}(newscopetag(), Binding{T, Sig}[], Dict{Symbol, Dict{Sig, LID}}())
 
@@ -855,7 +852,7 @@ hastag(hsl::HasScopeList, t::ScopeTag) =
 hasname(hsl::HasScopeList, name::Symbol) =
   haskey(getscopelist(hsl).namelookup, name)
 
-getidents(hsl::HasScopeList; kw...) = Iterators.flatten(getidents.(getscopelist(hsl)))
+getidents(hsl::HasScopeList; kw...) = vcat(getidents.(getscopelist(hsl))...)
 
 """
 Flatten a scopelist if possible. This will fail if any of the bindings shadow 

--- a/src/syntax/Scopes.jl
+++ b/src/syntax/Scopes.jl
@@ -611,7 +611,8 @@ getbinding(hs::HasScope, x::Ident) =
     throw(ScopeTagError(hs, x))
   end
 
-getbinding(hs::HasScope, name::Symbol) = getbinding(hs, getlid(hs, name; isunique=true))
+  getbinding(hs::HasScope, name::Symbol) = getbinding(hs, getlid(hs, name; isunique=true))
+  getbinding(hs::HasScope, xs::AbstractVector) = getbinding.(Ref(hs), xs)
 
 function ident(
   hs::HasScope;

--- a/src/syntax/Scopes.jl
+++ b/src/syntax/Scopes.jl
@@ -4,7 +4,7 @@ export
   ScopeTagError,
   LID,
   Ident, gettag, getlid, isnamed,
-  Binding, getvalue, getsignature, getline, setline,
+  Binding, getvalue, setvalue, getsignature, getline, setline,
   Context, getscope, nscopes, getlevel, hasname, hastag,
   HasContext, getcontext,
   hasident, ident, getidents, idents, canonicalize,
@@ -103,6 +103,8 @@ end
 function Base.show(io::IO, lid::LID)
   print(io, lid.val)
 end
+
+getvalue(lid::LID) = lid.val
 
 # Idents
 ########
@@ -244,6 +246,8 @@ getline(b::Binding) = b.line
 
 setline(b::Binding{T, Sig}, line::Union{LineNumberNode, Nothing}) where {T, Sig} =
   Binding{T, Sig}(b.primary, b.value, b.sig, line)
+setvalue(b::Binding{T, Sig}, t::T) where {T,Sig} = 
+  Binding{T, Sig}(b.primary, t, b.sig, b.line)
 
 # Context
 #########

--- a/src/syntax/module.jl
+++ b/src/syntax/module.jl
@@ -7,13 +7,13 @@ include("ExprInterop.jl")
 include("GATs.jl")
 include("Presentations.jl")
 include("TheoryInterface.jl")
-# include("TheoryMaps.jl")
+include("TheoryMaps.jl")
 
 @reexport using .Scopes
 @reexport using .ExprInterop
 @reexport using .GATs
 @reexport using .Presentations
 @reexport using .TheoryInterface
-# @reexport using .TheoryMaps
+@reexport using .TheoryMaps
 
 end

--- a/test/stdlib/models/GATs.jl
+++ b/test/stdlib/models/GATs.jl
@@ -11,7 +11,7 @@ using .ThCategory
 
   expected = @theorymap ThMonoid => ThNatPlus begin
     default => ℕ
-    x ⋅ y ⊣ [x, y] => y + x ⊣ [x::ℕ, y::ℕ]
+    x ⋅ y ⊣ [x, y] => y + x
     e => Z
   end
 

--- a/test/stdlib/models/tests.jl
+++ b/test/stdlib/models/tests.jl
@@ -6,6 +6,6 @@ include("FinMatrices.jl")
 include("SliceCategories.jl")
 include("Op.jl")
 include("Nothings.jl")
-# include("GATs.jl")
+include("GATs.jl")
 
 end

--- a/test/syntax/GATs.jl
+++ b/test/syntax/GATs.jl
@@ -40,16 +40,19 @@ three = AlgTerm(plus, [one, two])
 
 seg_expr = quote
   Ob :: TYPE
-  Hom(dom::Ob, codom::Ob) :: TYPE
-  id(a::Ob) :: Hom(a,a)
-  compose(f::Hom(a, b), g::Hom(b, c)) :: Hom(a, c) ⊣ [a::Ob, b::Ob, c::Ob]
+  Hom(dom, codom) :: TYPE ⊣ [dom::Ob, codom::Ob]
+  id(a) :: Hom(a,a) ⊣ [a::Ob]
+  compose(f, g) :: Hom(a, c) ⊣ [a::Ob, b::Ob, c::Ob, f::Hom(a, b), g::Hom(b, c)]
   ((compose(f, compose(g, h)) == compose(compose(f, g), h)) :: Hom(a,d)) ⊣ [
     a::Ob, b::Ob, c::Ob, d::Ob,
     f::Hom(a, b), g::Hom(b, c), h::Hom(c, d)
   ]
 end
 
+
 seg = fromexpr(TypeScope(), seg_expr, GATSegment)
+
+seg[ident(seg;name=:compose, isunique=true)].value.args
 
 @test toexpr(TypeScope(), seg) == seg_expr
 

--- a/test/syntax/GATs.jl
+++ b/test/syntax/GATs.jl
@@ -21,8 +21,8 @@ three = AlgTerm(plus, [one, two])
 
 @test toexpr(scope, three) == :((1::number) + (2::number))
 
-@test fromexpr(EmptyContext(), two.head, AlgTerm) == two
-@test_throws Exception fromexpr(EmptyContext(), :(x = 3), AlgTerm)
+@test fromexpr(TypeScope(), two.head, AlgTerm) == two
+@test_throws Exception fromexpr(TypeScope(), :(x = 3), AlgTerm)
 
 @test basicprinted(two) == "AlgTerm(2::number)"
 
@@ -34,10 +34,9 @@ three = AlgTerm(plus, [one, two])
 
 @test_throws Exception AlgSort(scope, three)
 
-
 # This throws a type error because it tries to look up `+` with a signature,
 # of AlgSorts, but `scope` only has nothing-typed signatures.
-@test_throws TypeError fromexpr(scope, toexpr(scope, three), AlgTerm) == three
+@test_throws TypeError fromexpr(scope, toexpr(scope, three), AlgTerm)
 
 seg_expr = quote
   Ob :: TYPE
@@ -50,11 +49,11 @@ seg_expr = quote
   ]
 end
 
-seg = fromexpr(EmptyContext(), seg_expr, GATSegment)
+seg = fromexpr(TypeScope(), seg_expr, GATSegment)
 
-@test toexpr(EmptyContext(), seg) == seg_expr
+@test toexpr(TypeScope(), seg) == seg_expr
 
-O, H, i, cmp = idents(seg; lid=LID.(1:4))
+O, H, i, cmp = getidents(seg)
 
 # Extend seg with a context of (A: Ob)
 sortscope = Scope([Binding{AlgType}(:A, AlgType(O))])

--- a/test/syntax/Presentations.jl
+++ b/test/syntax/Presentations.jl
@@ -9,7 +9,7 @@ tscope = parsetypescope(
   T, 
   :([(a,b,c)::Ob, f::Hom(a,b), g::Hom(b,c), (h,h′)::Hom(a,c)]).args
 )
-_, _, _, f, g, h, h′ = idents(tscope)
+_, _, _, f, g, h, h′ = getidents(tscope)
 h, h′ = AlgTerm.([h,h′])
 fg = fromexpr(AppendScope(T, tscope), :(compose(f,g)), AlgTerm)
 p1 = Presentation(T, tscope, [[fg, h]])

--- a/test/syntax/Scopes.jl
+++ b/test/syntax/Scopes.jl
@@ -190,7 +190,7 @@ xz_scope = Scope([bind_x, bind_z])
 @test valtype(xz_scope) == String
 
 c = ScopeList([xy_scope, xz_scope])
-@test sprint(show, c)[1:2 == "[{"
+@test sprint(show, c)[1:2] == "[{"
 
 @test_throws ErrorException Scopes.flatten(c)
 

--- a/test/syntax/Scopes.jl
+++ b/test/syntax/Scopes.jl
@@ -222,7 +222,7 @@ c = AppendScope(ScopeList([xy_scope]), xz_scope)
 @test nameof(ident(c; level=1, lid=LID(2))) == :y
 
 # EmptyContext 
-e = EmptyContext()
+e = EmptyContext{Nothing, Nothing}()
 @test_throws BoundsError getscope(e, 1)
 @test_throws KeyError getlevel(e, :x) 
 @test_throws KeyError getlevel(e, gettag(x))

--- a/test/syntax/Scopes.jl
+++ b/test/syntax/Scopes.jl
@@ -190,6 +190,8 @@ xz_scope = Scope([bind_x, bind_z])
 @test valtype(xz_scope) == String
 
 c = ScopeList([xy_scope, xz_scope])
+@test sprint(show, c)[1:2 == "[{"
+
 @test_throws ErrorException Scopes.flatten(c)
 
 @test getscope(c, 1) == xy_scope

--- a/test/syntax/TheoryMaps.jl
+++ b/test/syntax/TheoryMaps.jl
@@ -11,7 +11,7 @@ T2 = ThPreorder.THEORY
 
 # TheoryMaps 
 ############
-x = toexpr(PreorderCat);
+x = toexpr(PreorderCat)
 tm2 = fromexpr(T, T2, x, TheoryMap)
 x2 = toexpr(tm2)
 @test x == x2
@@ -56,10 +56,8 @@ end
 # Test PreorderCat
 
 (Ob, Hom), (Cmp, Id) = typecons(T), termcons(T)
-@test PreorderCat(Ob) == InCtx(T2, ident(T2; name=:default))
+@test PreorderCat(Ob).trm == AlgType(ident(T2; name=:default))
 @test PreorderCat(Cmp) isa TermInCtx
-
-PreorderCat(argcontext(getvalue(T[Cmp])))
 
 @test PreorderCat(argcontext(getvalue(T[Cmp]))) isa TypeScope
 

--- a/test/syntax/TheoryMaps.jl
+++ b/test/syntax/TheoryMaps.jl
@@ -59,7 +59,7 @@ end
 @test PreorderCat(Ob).trm == AlgType(ident(T2; name=:default))
 @test PreorderCat(Cmp) isa TermInCtx
 
-@test PreorderCat(argcontext(getvalue(T[Cmp]))) isa TypeScope
+@test PreorderCat(getvalue(T[Cmp]).localcontext) isa TypeScope
 
 @test_throws KeyError PreorderCat(first(typecons(T2)))
 
@@ -83,8 +83,8 @@ expected = :(compose(id(z), compose(q,  compose(p, id(x)))) ⊣ [x::Ob,y::Ob,z::
 
 OpCat2 = @theorymap ThCategory => ThCategory begin
   Ob => Ob
-  Hom(foo::Ob, bar::Ob) => Hom(bar, foo)
-  id(a::Ob) => id(a)
+  Hom(foo, bar) ⊣ [foo::Ob, bar::Ob] => Hom(bar, foo)
+  id(a) ⊣ [a::Ob] => id(a)
   compose(p,q) ⊣ [(z,y,x)::Ob, q::Hom(y,z), p::Hom(x,y)] => compose(q, p)
 end
 toexpr(T, OpCat2(xterm)) == expected

--- a/test/syntax/TheoryMaps.jl
+++ b/test/syntax/TheoryMaps.jl
@@ -79,6 +79,17 @@ expected = :(compose(id(z), compose(q,  compose(p, id(x)))) ⊣ [x::Ob,y::Ob,z::
 @test toexpr(T, OpCat(xterm)) == expected
 
 
+# Check that maps are not sensitive to order of bindings
+
+OpCat2 = @theorymap ThCategory => ThCategory begin
+  Ob => Ob
+  Hom(foo::Ob, bar::Ob) => Hom(bar, foo)
+  id(a::Ob) => id(a)
+  compose(p,q) ⊣ [(z,y,x)::Ob, q::Hom(y,z), p::Hom(x,y)] => compose(q, p)
+end
+toexpr(T, OpCat2(xterm)) == expected
+
+
 # Inclusions 
 #############
 TLC = ThLawlessCat.THEORY

--- a/test/syntax/tests.jl
+++ b/test/syntax/tests.jl
@@ -23,9 +23,9 @@ end
   include("TheoryInterface.jl")
 end
 
-@testset "TheoryMaps" begin
-  include("TheoryMaps.jl")
-end
+# @testset "TheoryMaps" begin
+#   include("TheoryMaps.jl")
+# end
 
 
 end

--- a/test/syntax/tests.jl
+++ b/test/syntax/tests.jl
@@ -23,9 +23,9 @@ end
   include("TheoryInterface.jl")
 end
 
-# @testset "TheoryMaps" begin
-#   include("TheoryMaps.jl")
-# end
+@testset "TheoryMaps" begin
+  include("TheoryMaps.jl")
+end
 
 
 end


### PR DESCRIPTION
TermInCtx and TypeInCtx are made more flexible to take a general context, rather than just a scope. This required making Context take {T, Sig} type parameters.

Previously we had conflicting meanings of `idents` - one was for broadcasting arguments to `ident` and the other was listing all the idents in a Context. The latter is now called `getidents`.

Also theory maps before required some redundancy in the expressions they parsed, this has been improved so that we can write `compose(f,g) ⊣ [(a,b,c)::Ob,f::Hom(a,b), g::Hom(b,c)] => compose(g, f)` with no explicit RHS context.
