### PR TITLE
infer axiom type + improved normalize_decl

### DIFF
--- a/src/stdlib/theories/Algebra.jl
+++ b/src/stdlib/theories/Algebra.jl
@@ -71,9 +71,9 @@ end
 @theory ThPreorder <: ThSet begin
   Leq(dom, codom)::TYPE
   @op (≤) := Leq
-  refl(p)::Leq(p,p)
+  refl(p)::Leq(p,p) ⊣ [p]
   trans(f::Leq(p,q),g::Leq(q,r))::Leq(p,r)  ⊣ [p,q,r]
-  irrev := f == g ::Leq(p,q) ⊣ [p,q, (f,g)::Leq(p,q)]
+  irrev := f == g :: Leq(p,q) ⊣ [p,q, (f,g)::Leq(p,q)]
 end
 
 end

--- a/src/stdlib/theories/Categories.jl
+++ b/src/stdlib/theories/Categories.jl
@@ -30,11 +30,11 @@ The data of a category without any axioms of associativity or identities.
 """ ThLawlessCat
 
 @theory ThAscCat <: ThLawlessCat begin
-  assoc := ((f ⋅ g) ⋅ h) == (f ⋅ (g ⋅ h)) :: Hom(a,d) ⊣
+  assoc := ((f ⋅ g) ⋅ h) == (f ⋅ (g ⋅ h)) ⊣
     [a::Ob, b::Ob, c::Ob, d::Ob, f::Hom(a,b), g::Hom(b,c), h::Hom(c,d)]
 end
 
-@doc """    ThAscCat
+@doc """    ThAsCat
 
 The theory of a category with the associative law for composition.
 """ ThAscCat
@@ -49,8 +49,8 @@ The theory of a category without identity axioms.
 """ ThIdLawlessCat
 
 @theory ThCategory <: ThIdLawlessCat begin
-  idl := id(a) ⋅ f == f :: Hom(a,b) ⊣ [a::Ob, b::Ob, f::Hom(a,b)]
-  idr := f ⋅ id(b) == f :: Hom(a,b) ⊣ [a::Ob, b::Ob, f::Hom(a,b)]
+  idl := id(a) ⋅ f == f ⊣ [a::Ob, b::Ob, f::Hom(a,b)]
+  idr := f ⋅ id(b) == f ⊣ [a::Ob, b::Ob, f::Hom(a,b)]
 end
 
 @doc """    ThCategory
@@ -59,7 +59,7 @@ The theory of a category with composition operations and associativity and ident
 """ ThCategory
 
 @theory ThThinCategory <: ThCategory begin
-  thineq := f == g :: Hom(A,B) ⊣ [A::Ob, B::Ob, f::Hom(A,B), g::Hom(A,B)]
+  thineq := f == g ⊣ [A::Ob, B::Ob, f::Hom(A,B), g::Hom(A,B)]
 end
 
 @doc """    ThThinCategory

--- a/src/stdlib/theories/Naturals.jl
+++ b/src/stdlib/theories/Naturals.jl
@@ -3,23 +3,22 @@ export ThNat, ThNatPlus, ThNatPlusTimes
 
 using ....Syntax
 
-# Natural numbers
+  # Natural numbers
+  @theory ThNat begin
+    ℕ :: TYPE
+    Z :: ℕ
+    S(n::ℕ) :: ℕ
+  end
 
-@theory ThNat begin
-  ℕ :: TYPE
-  Z :: ℕ
-  S(n::ℕ) :: ℕ
-end
+  @theory ThNatPlus <: ThNat begin
+    import Base: +
+    ((x::ℕ) + (y::ℕ))::ℕ
+    (n + S(m) == S(n+m) :: ℕ) ⊣ [n::ℕ,m::ℕ]
+  end
 
-@theory ThNatPlus <: ThNat begin
-  import Base: +
-  ((x::ℕ) + (y::ℕ))::ℕ
-  (n + S(m) == S(n+m) :: ℕ) ⊣ [n::ℕ,m::ℕ]
-end
-
-@theory ThNatPlusTimes <: ThNatPlus begin
-  ((x::ℕ) * (y::ℕ))::ℕ
-  (n * S(m) == ((n * m) + n) :: ℕ) ⊣ [n::ℕ,m::ℕ]
-end
+  @theory ThNatPlusTimes <: ThNatPlus begin
+    ((x::ℕ) * (y::ℕ))::ℕ
+    (n * S(m) == ((n * m) + n)) ⊣ [n::ℕ,m::ℕ]
+  end
 
 end


### PR DESCRIPTION
For compat with Catlab, we now can infer the type of an axiom declaration rather than requiring it to be manually specified.

Reminder that in general type inference can be ambiguous modulo the equations of a GAT - in the future we'll use E-graphs for this inference.