### PR TITLE
fix `make_alias_definitions` for catlab compatibility

### DIFF
--- a/src/models/ModelInterface.jl
+++ b/src/models/ModelInterface.jl
@@ -505,7 +505,7 @@ function make_alias_definitions(theory, theory_module, jltype_by_sort, model_typ
     for binding in segment
       alias = getvalue(binding)
       name = nameof(binding)
-      if alias isa Alias && nameof(alias.ref) ∉ ext_functions
+      if alias isa Alias && name ∉ ext_functions
         for (argsorts, method) in allmethods(theory.resolvers[alias.ref])
           args = [(gensym(), jltype_by_sort[sort]) for sort in argsorts]
           args = if oldinstance

--- a/src/nonstdlib/models/Pushouts.jl
+++ b/src/nonstdlib/models/Pushouts.jl
@@ -14,7 +14,7 @@ end
 using .ThPushout 
 
 @instance ThPushout{Int, Vector{Int}, PushoutInt} [model::FinSetC] begin
-  @import Ob, Hom, id, compose, dom, codom
+  @import Ob, Hom, id, compose, dom, codom, →, ⋅
   function pushout(sp::Span; context)
     B, C = context[:d], context[:c]
     d = DataStructures.IntDisjointSets(B+C)


### PR DESCRIPTION
A small change: originally, for a binding with name `→` declaring an alias to `Hom`, we would create code to make an alias definition if the name `→` was not found in `ext_functions` (the explicitly imported things in the `@instance` declaration). 

This was changed in a PR of mine because it seemed like one would more likely write `import Hom` rather than `import →`. To my surprise, this is causing regressions in Catlab. I haven't gotten to the bottom of why, but for the time being I'm rolling back this change.