### PR TITLE
Fix precompilation warning about unordered dicts

### DIFF
--- a/src/syntax/gats/gat.jl
+++ b/src/syntax/gats/gat.jl
@@ -78,9 +78,9 @@ function GAT(name::Symbol)
   GAT(
     name,
     ScopeList{Judgment}(),
-    Dict{Ident, MethodResolver}(),
+    OrderedDict{Ident, MethodResolver}(),
     AlgSort[],
-    Dict{Ident, Dict{Int, Ident}}(),
+    OrderedDict{Ident, Dict{Int, Ident}}(),
     Ident[],
   )
 end


### PR DESCRIPTION
Addresses a warning that GATlab is currently emitting. (https://github.com/AlgebraicJulia/GATlab.jl/issues/124)