### PR TITLE
Simple theory maps and simple pushouts

### DIFF
--- a/src/syntax/Scopes.jl
+++ b/src/syntax/Scopes.jl
@@ -4,7 +4,7 @@ export
   ScopeTagError,
   LID,
   Ident, Alias, gettag, getlid, isnamed,
-  Binding, getvalue, setvalue, getline, setline,
+  Binding, getvalue, setname, setvalue, getline, setline,
   Context, getscope, nscopes, getlevel, hasname, hastag, alltags, allscopes,
   HasContext, getcontext,
   hasident, ident, getidents, idents, canonicalize,
@@ -155,14 +155,14 @@ function Base.show(io::IO, x::Ident)
 end
 
 retag(replacements::Dict{ScopeTag, ScopeTag}, x::Ident) =
-  if gettag(x) ∈ keys(replacements)
+  if haskey(replacements, gettag(x))
     Ident(replacements[gettag(x)], getlid(x), nameof(x))
   else
     x
   end
 
 rename(tag::ScopeTag, replacements::Dict{Symbol, Symbol}, x::Ident) =
-  if gettag(x) == tag && nameof(x) ∈ keys(replacements)
+  if haskey(replacements, nameof(x)) && gettag(x) == tag
     Ident(tag, getlid(x), replacements[nameof(x)])
   else
     x

--- a/src/syntax/gats/gat.jl
+++ b/src/syntax/gats/gat.jl
@@ -119,19 +119,16 @@ function unsafe_updatecache!(theory::GAT, x::Ident, judgment::AlgStruct)
   theory.accessors[x] = Dict{Int, Ident}()
 end
 
-
 function unsafe_updatecache!(theory::GAT, x::Ident, judgment::AlgAccessor)
   addmethod!(theory.resolvers[getdecl(judgment)], sortsignature(judgment), x)
   theory.accessors[judgment.typecon][judgment.arg] = x
 end
 
-function unsafe_updatecache!(theory::GAT, x::Ident, judgment::AlgAxiom)
+function unsafe_updatecache!(theory::GAT, x::Ident, ::AlgAxiom)
   push!(theory.axioms, x)
 end
 
-function unsafe_updatecache!(theory::GAT, x::Ident, judgment::Alias)
-  nothing
-end
+unsafe_updatecache!(::GAT, ::Ident, ::Alias) = nothing
 
 function Scopes.unsafe_pushbinding!(theory::GAT, binding::Binding{Judgment})
   x = Scopes.unsafe_pushbinding!(theory.segments, binding)
@@ -172,6 +169,57 @@ function Base.show(io::IO, theory::GAT)
       println(io, "  ", line)
     end
   end
+end
+
+# Merging overlapping GATs
+
+"""
+There is no shadowing allowed in GATs, so if the new theory shares an 
+AlgDeclaration name with the base theory, the new theory Idents which refer 
+to that name should instead be retagged to refer to the AlgDeclaration in the 
+base theory.
+
+Returns a Dict mapping idents from the merged-in theory into the modified base 
+theory.
+"""
+function Base.union!(base::GAT, theory::GAT)
+  dict = Dict{Ident,Ident}()
+  for xs in theory.segments.scopes
+    unsafe_newsegment!(base)
+    for (x, v) in identvalues(xs)
+      if v isa AlgDeclaration 
+        if !hasident(base; name=nameof(x)) 
+          Scopes.unsafe_pushbinding!(base, theory[x])
+        end
+        dict[x] = ident(base; name=nameof(x))
+      else
+        x′ = nothing
+        v′ = reident(dict, v)
+        set = setvalue(theory[x], v′)
+        if v isa TrmTypConstructor
+          sig = sortsignature(v′)
+          res = base.resolvers[v′.declaration].bysignature
+          x′ = haskey(res, sig) ? res[sig] : Scopes.unsafe_pushbinding!(base, set)
+        elseif v isa AlgAxiom
+          for ax in base.axioms
+            axiom = getvalue(base[ax])
+            actx, vctx = getcontext.([axiom, v])
+            if values(actx) == [reident(dict, t) for t in values(vctx)]
+              dic = Dict([pairs(dict)..., zip(getidents.([vctx,actx])...)...])
+              if axiom.equands == [reident(dic, eq) for eq in v.equands]
+                x′ = ax
+              end
+            end
+          end
+          if isnothing(x′) 
+            x′ = Scopes.unsafe_pushbinding!(base, set)
+          end
+        end
+        dict[x] = x′
+      end
+    end
+  end
+  dict
 end
 
 # Accessors
@@ -218,6 +266,8 @@ function typecons(theory::GAT)
   xs
 end
 
+Base.iterate(t::GAT) = iterate(collect(t))
+Base.iterate(t::GAT, i) = iterate(collect(t), i)
 
 Base.issubset(t1::GAT, t2::GAT) =
   all(s->hastag(t2, s), gettag.(Scopes.getscopelist(t1).scopes))

--- a/src/syntax/gats/gat.jl
+++ b/src/syntax/gats/gat.jl
@@ -219,7 +219,7 @@ function Base.union!(base::GAT, theory::GAT)
       end
     end
   end
-  dict
+  return dict
 end
 
 # Accessors
@@ -265,9 +265,6 @@ function typecons(theory::GAT)
   end
   xs
 end
-
-Base.iterate(t::GAT) = iterate(collect(t))
-Base.iterate(t::GAT, i) = iterate(collect(t), i)
 
 Base.issubset(t1::GAT, t2::GAT) =
   all(s->hastag(t2, s), gettag.(Scopes.getscopelist(t1).scopes))

--- a/test/syntax/GATs.jl
+++ b/test/syntax/GATs.jl
@@ -143,6 +143,23 @@ end
   id_span(x) := Span(x, id(x),id(x)) ⊣ [x::Ob]
 end
 
+# Union
+#######
+
+@theory ThMonoid2 <: ThSemiGroup begin
+  e() :: default
+  e() ⋅ x == x ⊣ [x]
+  x ⋅ e() == x ⊣ [x]
+  e() ⋅ e() == e() ⊣ [x]
+end
+
+T, T′ = deepcopy.([ThMonoid.Meta.theory, ThMonoid2.Meta.theory]);
+@test length(T.axioms) == 3
+dic = union!(T, T′)
+@test dic isa Dict
+@test length(T.axioms) == 4
+@test length(termcons(T)) == 2
+@test length(typecons(T)) == 1
 
 
 end # module

--- a/test/syntax/TheoryMaps.jl
+++ b/test/syntax/TheoryMaps.jl
@@ -142,7 +142,6 @@ expected = :((x + y) + Z() ⊣ [x::default, y::default])
 GATs.parseaxiom!(TM′, fromexpr(TM′, :([x, y]), TypeScope), nothing, 
                         :((x + y) == (y + x)))
 
-
 lft = TheoryIncl(ThSet.Meta.theory, TM)
 rght = TheoryMaps.compose(lft, m)
  

--- a/test/syntax/TheoryMaps.jl
+++ b/test/syntax/TheoryMaps.jl
@@ -15,6 +15,8 @@ TNP = ThNatPlus.Meta.theory
 PC = PreorderCat.MAP
 NP = NatPlusMonoid.MAP
 
+using .ThCategory
+
 # TheoryMaps 
 ############
 x = toexpr(PC)
@@ -101,24 +103,73 @@ end
 # Inclusions 
 #############
 incl = TheoryIncl(TLC, T)
-@test TheoryMaps.dom(incl) == TLC
-@test TheoryMaps.codom(incl) == T
+@test dom[GATC()](incl) == TLC
+@test codom[GATC()](incl) == T
 incl2 = TheoryIncl(ThGraph.Meta.theory, TLC)
 incl3 = TheoryIncl(ThGraph.Meta.theory, T)
 
-@test TheoryMaps.compose(incl2, incl) == incl3
+@test compose[GATC()](incl2, incl) == incl3
 
 toexpr(incl)
-@test_throws ErrorException TheoryIncl(T, TLC)
+# @test_throws ErrorException TheoryIncl(T, TLC) # we no longer check for this
 @test_throws ErrorException inv(incl)
 
 # Identity 
 ##########
 i = IdTheoryMap(T)
-@test TheoryMaps.dom(i) == T
-@test TheoryMaps.codom(i) == T
-@test TheoryMaps.compose(i,i) == i
-@test TheoryMaps.compose(incl,i) == incl
+@test dom[GATC()](i) == T
+@test codom[GATC()](i) == T
+@test compose[GATC()](i, i) == i
+@test compose[GATC()](incl, i) == incl
 
+# Renaming
+##########
+
+m = rename(TM, Dict(:⋅=>:+, :e => :Z); name=:ThCommMonoid)
+TM′ = codom[GATC()](m)
+m′ = SimpleTheoryMap(TM, TM′, Dict(:⋅=>:+, :e=>:Z))
+@test m == m′
+
+xterm = fromexpr(TM, :((x ⋅ y) ⋅ e() ⊣ [(x,y)::default]), TermInCtx)
+expected = :((x + y) + Z() ⊣ [x::default, y::default])
+@test toexpr(TM′, m(xterm)) == expected
+
+
+# Pushouts of simple theorymaps via renaming
+#-------------------------------------------
+
+# Add commutativity of addition
+GATs.parseaxiom!(TM′, fromexpr(TM′, :([x, y]), TypeScope), nothing, 
+                        :((x + y) == (y + x)))
+
+
+lft = TheoryIncl(ThSet.Meta.theory, TM)
+rght = TheoryMaps.compose(lft, m)
+ 
+ι₁,ι₂ = TheoryMaps.pushout(lft, rght; name=:PreRing) # basically union!, since no name collisions
+@test codom[GATC()](ι₁) == codom[GATC()](ι₂)
+ThPreRing = codom[GATC()](ι₁)
+@test dom[GATC()](ι₁) == TM 
+@test dom[GATC()](ι₂) == TM′
+
+# do the renaming in the inclusion maps themselves
+#--------------------------------------------
+@theory CommMonoid <: ThMonoid begin
+  x⋅y == y⋅x ⊣ [x,y]
+end
+
+lft = TheoryIncl(ThSet.Meta.theory, TM)
+rght = TheoryIncl(ThSet.Meta.theory, CommMonoid.Meta.theory)
+
+ι₁,ι₂ = TheoryMaps.pushout(lft, rght; name=:PreRing, 
+                names=[Dict{Symbol,Symbol}(), Dict(:e=>:Z,:⋅=>:+)])
+@test codom[GATC()](ι₁) == codom[GATC()](ι₂)
+ThPreRing = codom[GATC()](ι₁)
+@test dom[GATC()](ι₁) == TM 
+@test dom[GATC()](ι₂) == CommMonoid.Meta.theory
+
+x = last(last.(termcons(TM))) # monoid unit
+exprs = [toexpr(ThPreRing,getvalue(f(x))) for f in [ι₁,ι₂]]
+@test exprs == [:(e()), :(Z())] # same termcon mapped to two different ones
 
 end # module


### PR DESCRIPTION
This adds a new instance of `AbsTheoryMap` which maps generators to generators, rather than to complex terms. For this kind of map we can easily compute pushouts, which is a matter of renaming.

The universal property of these colimits is not yet implemented.

Also, this is all at the `GAT` data structure level, rather than the module level.