### PR TITLE
Import equations from AlgebraicInterfaces and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ StructEquality = "6ec83bb0-ed9f-11e9-3b4c-2b04cb4e219c"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-AlgebraicInterfaces = "0.1"
+AlgebraicInterfaces = "0.1.3"
 Colors = "0.12"
 Crayons = "4"
 DataStructures = "0.18"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GATlab"
 uuid = "f0ffcf3b-d13a-433e-917c-cc44ccf5ead2"
 authors = ["AlgebraicJulia Developers"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 AlgebraicInterfaces = "23cfdc9f-0504-424a-be1f-4892b28e2f0c"

--- a/src/syntax/GATs.jl
+++ b/src/syntax/GATs.jl
@@ -16,6 +16,8 @@ import ..ExprInterop: fromexpr, toexpr
 
 import ..Scopes: retag, rename
 
+import AlgebraicInterfaces: equations
+
 using StructEquality
 using MLStyle
 using DataStructures: OrderedDict


### PR DESCRIPTION
Now that ACSets.jl exports `equations`, and Catlab inherits from both ACSets and GATlab, I have added `equations` to AlgebraicInteraces so that both ACSets and GATlab can extend the same function. This PR also bumps the version number so that we can cut a new minor release before integrating with Catlab.