### PR TITLE
Use `getvalue` from AlgebraicInterfaces

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GATlab"
 uuid = "f0ffcf3b-d13a-433e-917c-cc44ccf5ead2"
 authors = ["AlgebraicJulia Developers"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 AlgebraicInterfaces = "23cfdc9f-0504-424a-be1f-4892b28e2f0c"
@@ -17,7 +17,7 @@ StructEquality = "6ec83bb0-ed9f-11e9-3b4c-2b04cb4e219c"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-AlgebraicInterfaces = "0.1.3"
+AlgebraicInterfaces = "0.1.4"
 Colors = "0.12"
 Crayons = "4"
 DataStructures = "0.18"

--- a/src/syntax/Scopes.jl
+++ b/src/syntax/Scopes.jl
@@ -18,6 +18,7 @@ using MLStyle
 using StructEquality
 using Crayons
 import Base: rest
+import AlgebraicInterfaces: getvalue
 
 using ...Util
 


### PR DESCRIPTION
Now that `getvalue` is also used in ACSets.jl, we need to import this method from AlgebraicInterfaces so that downstream packages like Catlab can use `getvalue` without it being ambiguous.