### PR TITLE
Fix logic of `@import`

### DIFF
--- a/src/models/ModelInterface.jl
+++ b/src/models/ModelInterface.jl
@@ -387,11 +387,7 @@ function typecheck_instance(
 
   overload_errormsg =
    "the types for this model declaration do not permit Julia overloading to distinguish between GAT overloads"
-
   for (decl, resolver) in theory.resolvers
-    if nameof(decl) ∈ ext_functions
-      continue
-    end
     for (_, x) in allmethods(resolver)
       if getvalue(theory[x]) isa AlgStruct 
         continue 
@@ -455,6 +451,7 @@ function typecheck_instance(
   end
 
   for (sig, (decl, method)) in undefined_signatures
+    nameof(decl) ∈ ext_functions && continue # assume it has been impl'd already
     judgment = getvalue(theory[method])
     if judgment isa AlgTermConstructor
       error("Failed to implement $decl: $(toexpr(sig))")

--- a/src/syntax/TheoryInterface.jl
+++ b/src/syntax/TheoryInterface.jl
@@ -153,11 +153,12 @@ function theory_impl(head, body, __module__)
   end
   
   doctarget = gensym()
+  mdp(::Nothing) = []
+  mdp(x::Base.Docs.DocStr) = Markdown.parse(x.text...)
 
   push!(modulelines, Expr(:toplevel, :(module Meta
     struct T end
    
-    @doc ($(Markdown.MD)((@doc $(__module__).$doctarget), $docstr))
     const theory = $theory
 
     macro theory() $theory end
@@ -180,7 +181,7 @@ function theory_impl(head, body, __module__)
         $(structlines...)
         end
       ),
-      :(@doc ($(Markdown.MD)((@doc $doctarget), $docstr)) $name)
+      :(@doc ($(Markdown.MD)($mdp(@doc $doctarget), $docstr)) $name)
     )
   )
 end

--- a/src/syntax/TheoryInterface.jl
+++ b/src/syntax/TheoryInterface.jl
@@ -154,6 +154,7 @@ function theory_impl(head, body, __module__)
   
   doctarget = gensym()
   mdp(::Nothing) = []
+  mdp(::Markdown.MD) = [x]
   mdp(x::Base.Docs.DocStr) = Markdown.parse(x.text...)
 
   push!(modulelines, Expr(:toplevel, :(module Meta

--- a/src/syntax/TheoryInterface.jl
+++ b/src/syntax/TheoryInterface.jl
@@ -154,7 +154,7 @@ function theory_impl(head, body, __module__)
   
   doctarget = gensym()
   mdp(::Nothing) = []
-  mdp(::Markdown.MD) = [x]
+  mdp(x::Markdown.MD) = x
   mdp(x::Base.Docs.DocStr) = Markdown.parse(x.text...)
 
   push!(modulelines, Expr(:toplevel, :(module Meta

--- a/test/models/ModelInterface.jl
+++ b/test/models/ModelInterface.jl
@@ -170,4 +170,30 @@ end
   munit() = 0
 end
 
+# Test scenario where we @import a method but then extend it
+############################################################
+@theory T1 begin 
+  X::TYPE; 
+  h(a::X)::X 
+end
+
+@theory T2<:T1 begin 
+  Y::TYPE; 
+  h(b::Y)::Y 
+end
+
+@instance T1{Int} begin 
+  h(a::Int) = 1 
+end
+
+@instance T2{Int,Bool} begin 
+  @import X, h
+  h(b::Bool) = false 
+end
+
+@test h(2) == 1
+
+@test h(false) == false
+
+
 end # module

--- a/test/syntax/TheoryInterface.jl
+++ b/test/syntax/TheoryInterface.jl
@@ -46,7 +46,8 @@ end
   @op 1 + 1
 end
 
-@test (@doc ThCMonoid.Meta.theory) isa Markdown.MD
-@test (@doc ThSet) == (@doc ThSet.Meta.theory)
+# DEPRECATED
+# @test (@doc ThCMonoid.Meta.theory) isa Markdown.MD
+# @test (@doc ThSet) == (@doc ThSet.Meta.theory)
 
 end


### PR DESCRIPTION
Addresses https://github.com/AlgebraicJulia/GATlab.jl/issues/167

This changes what `@import` does within the `@instance` macro. Rather than removing expected signatures, whenever we have leftover unimplemented signatures we check if the name of the method is in the imports and ignore the missing method error if so.

I've tested that this doesn't break Catlab.