### PR TITLE
Remove the `Model` abstract type, simplify model migration code.

### DIFF
--- a/src/models/ModelInterface.jl
+++ b/src/models/ModelInterface.jl
@@ -387,11 +387,7 @@ function typecheck_instance(
 
   overload_errormsg =
    "the types for this model declaration do not permit Julia overloading to distinguish between GAT overloads"
-
   for (decl, resolver) in theory.resolvers
-    if nameof(decl) ∈ ext_functions
-      continue
-    end
     for (_, x) in allmethods(resolver)
       if getvalue(theory[x]) isa AlgStruct 
         continue 
@@ -455,6 +451,7 @@ function typecheck_instance(
   end
 
   for (sig, (decl, method)) in undefined_signatures
+    nameof(decl) ∈ ext_functions && continue # assume it has been impl'd already
     judgment = getvalue(theory[method])
     if judgment isa AlgTermConstructor
       error("Failed to implement $decl: $(toexpr(sig))")

--- a/src/models/ModelInterface.jl
+++ b/src/models/ModelInterface.jl
@@ -514,7 +514,7 @@ function make_alias_definitions(theory, theory_module, jltype_by_sort, model_typ
               args
             end
           else
-            [(gensym(:m), :($(TheoryInterface.WithModel){$model_type})); args]
+            [(gensym(:m), :($(TheoryInterface.WithModel){<:$model_type})); args]
           end
           argexprs = [Expr(:(::), p...) for p in args]
           overload = JuliaFunction(;
@@ -560,7 +560,7 @@ function qualify_function(fun::JuliaFunction, theory_module, model_type::Union{E
 
     m = gensym(:m)
     (
-      [Expr(:(::), m, Expr(:curly, TheoryInterface.WithModel, model_type)), args...],
+      [Expr(:(::), m, Expr(:curly, TheoryInterface.WithModel, Expr(:<:, model_type))), args...],
       Expr(:let, Expr(:(=), :model, :($m.model)), fun.impl)
     )
   else

--- a/src/models/ModelInterface.jl
+++ b/src/models/ModelInterface.jl
@@ -649,6 +649,10 @@ function migrator(tmap, dom_module, codom_module, dom_theory, codom_theory)
     v => whereparamdict[AlgSort(tmap(v.method).val)]
   end)
 
+  whereparams2 = map(sorts(dom_theory)) do v
+    whereparamdict[AlgSort(tmap(v.method).val)]
+  end
+
   # Create input for instance_code
   ################################
   accessor_funs = JuliaFunction[] # added to during typecon_funs loop
@@ -726,11 +730,12 @@ function migrator(tmap, dom_module, codom_module, dom_theory, codom_theory)
   )
 
   tup_params = Expr(:curly, :Tuple, whereparams...)
+  tup_params2 = Expr(:curly, :Tuple, whereparams2...)
 
   model_expr = Expr(
     :curly,
     GlobalRef(Syntax.TheoryInterface, :Model),
-    tup_params
+    tup_params2 # Types associated with *domain* sorts
   )
 
   # The second whereparams needs to be reordered by the sorts of the DOM theory

--- a/src/nonstdlib/models/Pushouts.jl
+++ b/src/nonstdlib/models/Pushouts.jl
@@ -2,8 +2,6 @@ using DataStructures, StructEquality
 
 export PushoutInt
 
-using GATlab
-
 """Data required to specify a pushout. No fancy caching."""
 @struct_hash_equal struct PushoutInt
   ob::Int

--- a/src/stdlib/derivedmodels/DerivedModels.jl
+++ b/src/stdlib/derivedmodels/DerivedModels.jl
@@ -6,7 +6,7 @@ using ...StdTheoryMaps
 using ...StdModels
 
 # Given a model of a category C, we can derive a model of Cᵒᵖ.
-OpFinSetC = migrate_model(OpCat, FinSetC())
+OpFinSetC = migrate_model(OpCat, FinSetC(), :OpFinSetCat)
 
 # Interpret `e` as `0` and `⋅` as `+`.
 IntMonoid = migrate_model(NatPlusMonoid, IntNatPlus())

--- a/src/stdlib/models/arithmetic.jl
+++ b/src/stdlib/models/arithmetic.jl
@@ -3,14 +3,14 @@ export IntNat, IntNatPlus, IntPreorder, ZRing, BoolRing
 using ...Models
 using ..StdTheories
 
-struct IntNat <: Model{Tuple{Int}} end
+struct IntNat end
 
 @instance ThNat{Int} [model::IntNat] begin
   Z() = 0
   S(n::Int) = n + 1
 end
 
-struct IntNatPlus <: Model{Tuple{Int}} end
+struct IntNatPlus end
 
 @instance ThNatPlus{Int} [model::IntNatPlus] begin
   Z() = 0
@@ -18,7 +18,7 @@ struct IntNatPlus <: Model{Tuple{Int}} end
   +(x::Int, y::Int) = x + y
 end
 
-struct IntPreorder <: Model{Tuple{Int, Tuple{Int,Int}}} end
+struct IntPreorder end
 
 @instance ThPreorder{Int, Tuple{Int,Int}} [model::IntPreorder] begin
   Leq(ab::Tuple{Int,Int}, a::Int, b::Int) = a ≤ b ? ab : @fail "$(ab[1]) ≰ $(ab[2])"
@@ -30,7 +30,7 @@ struct IntPreorder <: Model{Tuple{Int, Tuple{Int,Int}}} end
   end
 end
 
-struct ZRing <: Model{Tuple{Int}} end
+struct ZRing end
 
 @instance ThRing{Int} [model::ZRing] begin
   zero() = 0

--- a/src/stdlib/models/finmatrices.jl
+++ b/src/stdlib/models/finmatrices.jl
@@ -3,8 +3,7 @@ export FinMatC
 using ...Models
 using ..StdTheories
 
-struct FinMatC{T<:Number} <: Model{Tuple{T}}
-end
+struct FinMatC{T <: Number} end
 
 @instance ThCategory{Int, Matrix{T}} [model::FinMatC{T}] where {T} begin
   Ob(n::Int) = n >= 0 ? n : @fail "expected nonnegative integer"

--- a/src/stdlib/models/finsets.jl
+++ b/src/stdlib/models/finsets.jl
@@ -3,8 +3,7 @@ export FinSetC
 using ...Models
 using ..StdTheories
 
-struct FinSetC <: Model{Tuple{Int, Vector{Int}}}
-end
+struct FinSetC end
 
 @instance ThCategory{Int, Vector{Int}} [model::FinSetC] begin
   Ob(x::Int) = x >= 0 ? x : @fail "expected nonnegative integer"

--- a/src/stdlib/models/gats.jl
+++ b/src/stdlib/models/gats.jl
@@ -4,10 +4,7 @@ using ...Models
 using ...Syntax
 using ..StdTheories
 
-using GATlab, GATlab.Models
-
-struct GATC <: Model{Tuple{GAT, AbsTheoryMap}}
-end
+struct GATC end
 
 @instance ThCategory{GAT, AbsTheoryMap} [model::GATC] begin
   id(x::GAT) = IdTheoryMap(x)

--- a/src/stdlib/models/nothings.jl
+++ b/src/stdlib/models/nothings.jl
@@ -2,8 +2,7 @@ export NothingC
 
 using ...Models, ..StdTheories
 
-struct NothingC <: Model{Tuple{Nothing, Nothing}}
-end
+struct NothingC end
 
 @instance ThCategory{Nothing, Nothing} [model::NothingC] begin
   Ob(::Nothing) = nothing

--- a/src/stdlib/models/op.jl
+++ b/src/stdlib/models/op.jl
@@ -10,8 +10,17 @@ using ...Models
 using ..StdTheories
 using StructEquality
 
-@struct_hash_equal struct OpC{ObT, HomT, C<:Model{Tuple{ObT, HomT}}} <: Model{Tuple{ObT, HomT}}
-  cat::C
+# TODO when we implement custom structs for models of a particular theory, we 
+# can use that rather than a generic "C" for which we then have to check 
+# whether it implements the theory.
+
+@struct_hash_equal struct OpC{ObT, HomT, C}
+  cat::C 
+  function OpC(c::C) where C 
+    obtype = impl_type(c, ThCategory, :Ob)
+    homtype = impl_type(c, ThCategory, :Hom)
+    implements(c, ThCategory) ? new{obtype, homtype, C}(c) : error("bad")
+  end
 end
 
 op(c) = OpC(c)

--- a/src/stdlib/models/slicecategories.jl
+++ b/src/stdlib/models/slicecategories.jl
@@ -9,13 +9,15 @@ using StructEquality
   hom::HomT
 end
 
-@struct_hash_equal struct SliceC{ObT, HomT, C<:Model{Tuple{ObT, HomT}}} <: Model{Tuple{SliceOb{ObT, HomT}, HomT}}
+@struct_hash_equal struct SliceC{ObT, HomT, C}
   cat::C
   over::ObT
-  # function SliceC(cat, over)
-  #   implements(cat, ThCategory)
-  #   new(cat, Ob[cat](over))
-  # end
+  function SliceC(cat::C, over) where C
+    implements(cat, ThCategory) || error("Bad cat $cat")
+    obtype = impl_type(cat, ThCategory, :Ob)
+    homtype = impl_type(cat, ThCategory, :Hom)
+    new{obtype, homtype, C}(cat, ThCategory.Ob[cat](over))
+  end
 end
 
 using .ThCategory

--- a/src/syntax/GATs.jl
+++ b/src/syntax/GATs.jl
@@ -14,7 +14,7 @@ export Constant, AlgTerm, AlgType, AlgAST,
 using ..Scopes
 import ..ExprInterop: fromexpr, toexpr
 
-import ..Scopes: retag, rename, reident
+import ..Scopes: retag, rename, reident, gettag
 
 import AlgebraicInterfaces: equations
 

--- a/src/syntax/TheoryInterface.jl
+++ b/src/syntax/TheoryInterface.jl
@@ -153,11 +153,12 @@ function theory_impl(head, body, __module__)
   end
   
   doctarget = gensym()
+  mdp(::Nothing) = []
+  mdp(x::Base.Docs.DocStr) = Markdown.parse(x.text...)
 
   push!(modulelines, Expr(:toplevel, :(module Meta
     struct T end
    
-    @doc ($(Markdown.MD)((@doc $(__module__).$doctarget), $docstr))
     const theory = $theory
 
     macro theory() $theory end
@@ -180,7 +181,7 @@ function theory_impl(head, body, __module__)
         $(structlines...)
         end
       ),
-      :(@doc ($(Markdown.MD)((@doc $doctarget), $docstr)) $name)
+      :(@doc ($(Markdown.MD)($mdp(@doc $doctarget), $docstr)) $name)
     )
   )
 end

--- a/src/syntax/TheoryInterface.jl
+++ b/src/syntax/TheoryInterface.jl
@@ -1,14 +1,11 @@
 module TheoryInterface
-export @theory, @signature, Model, invoke_term
+export @theory, @signature, invoke_term
 
 using ..Scopes, ..GATs, ..ExprInterop, GATlab.Util
-# using GATlab.Util
 
 using MLStyle, StructEquality, Markdown
 
-abstract type Model{Tup <: Tuple} end
-
-@struct_hash_equal struct WithModel{M <: Model}
+@struct_hash_equal struct WithModel{M}
   model::M
 end
 
@@ -191,8 +188,8 @@ function juliadeclaration(name::Symbol)
   quote
     function $name end
 
-    if Base.isempty(Base.methods(Base.getindex, [typeof($name), $(GlobalRef(TheoryInterface, :Model))]))
-      function Base.getindex(::typeof($name), m::$(GlobalRef(TheoryInterface, :Model)))
+    if Base.isempty(Base.methods(Base.getindex, [typeof($name), Any]))
+      function Base.getindex(::typeof($name), m::Any) 
         (args...; context=nothing) -> $name($(GlobalRef(TheoryInterface, :WithModel))(m), args...; context)
       end
     end

--- a/src/syntax/TheoryInterface.jl
+++ b/src/syntax/TheoryInterface.jl
@@ -154,6 +154,7 @@ function theory_impl(head, body, __module__)
   
   doctarget = gensym()
   mdp(::Nothing) = []
+  mdp(::Markdown.MD) = [x]
   mdp(x::Base.Docs.DocStr) = Markdown.parse(x.text...)
 
   push!(modulelines, Expr(:toplevel, :(module Meta

--- a/src/syntax/TheoryInterface.jl
+++ b/src/syntax/TheoryInterface.jl
@@ -154,7 +154,7 @@ function theory_impl(head, body, __module__)
   
   doctarget = gensym()
   mdp(::Nothing) = []
-  mdp(::Markdown.MD) = [x]
+  mdp(x::Markdown.MD) = x
   mdp(x::Base.Docs.DocStr) = Markdown.parse(x.text...)
 
   push!(modulelines, Expr(:toplevel, :(module Meta

--- a/src/syntax/TheoryMaps.jl
+++ b/src/syntax/TheoryMaps.jl
@@ -402,8 +402,6 @@ macro theorymap(head, body)
   codom = macroexpand(__module__, :($codomname.Meta.@theory))
   tmap = fromexpr(dom, codom, body, TheoryMap)
 
-  mig = migrator(tmap, dommod, codommod, dom, codom)
-
   esc(
     Expr(
       :toplevel,
@@ -413,8 +411,6 @@ macro theorymap(head, body)
           macro map() $tmap end
           macro dom() $dommod end
           macro codom() $codommod end
-
-          $mig
         end
       ),
       :(Core.@__doc__ $(name)),

--- a/src/syntax/gats/gat.jl
+++ b/src/syntax/gats/gat.jl
@@ -379,3 +379,5 @@ end
 
 """Get all structs in a theory"""
 structs(t::GAT) = AlgStruct[getvalue(t[methodof(s)]) for s in struct_sorts(t)]
+
+gettag(T::GAT) = gettag(T.segments.scopes[end])

--- a/test/models/ModelInterface.jl
+++ b/test/models/ModelInterface.jl
@@ -170,4 +170,30 @@ end
   munit() = 0
 end
 
+# Test scenario where we @import a method but then extend it
+############################################################
+@theory T1 begin 
+  X::TYPE; 
+  h(a::X)::X 
+end
+
+@theory T2<:T1 begin 
+  Y::TYPE; 
+  h(b::Y)::Y 
+end
+
+@instance T1{Int} begin 
+  h(a::Int) = 1 
+end
+
+@instance T2{Int,Bool} begin 
+  @import X, h
+  h(b::Bool) = false 
+end
+
+@test h(2) == 1
+
+@test h(false) == false
+
+
 end # module

--- a/test/models/ModelInterface.jl
+++ b/test/models/ModelInterface.jl
@@ -1,11 +1,8 @@
 module TestModelInterface 
 
-using GATlab
-using Test
-using StructEquality
+using GATlab, Test, StructEquality
 
-@struct_hash_equal struct FinSetC <: Model{Tuple{Int, Vector{Int}}}
-end
+@struct_hash_equal struct FinSetC end
 
 @instance ThCategory{Int, Vector{Int}} [model::FinSetC] begin
   # check f is Hom: n -> m
@@ -58,7 +55,7 @@ end
 @test implements(FinSetC(), ThCategory)
 
 # Todo: get things working where Ob and Hom are the same type (i.e. binding dict not monic)
-struct TypedFinSetC <: Model{Tuple{Vector{Int}, Vector{Int}}}
+struct TypedFinSetC
   ntypes::Int
 end
 
@@ -199,7 +196,7 @@ end
 #################################
  
 """ Assume this implements Base.iterate """
-abstract type MyAbsIter{V} <: Model{Tuple{V}} end
+abstract type MyAbsIter{V} end
 
 struct MyVect{V} <: MyAbsIter{V}
   v::Vector{V}

--- a/test/models/ModelInterface.jl
+++ b/test/models/ModelInterface.jl
@@ -195,5 +195,25 @@ end
 
 @test h(false) == false
 
+# Test models with abstract types 
+#################################
+ 
+""" Assume this implements Base.iterate """
+abstract type MyAbsIter{V} <: Model{Tuple{V}} end
+
+struct MyVect{V} <: MyAbsIter{V}
+  v::Vector{V}
+end
+
+Base.iterate(m::MyVect, i...) = iterate(m.v, i...)
+
+@instance ThSet{V} [model::MyAbsIter{V}] where V begin 
+  default(v::V) = v ∈ model ? v : @fail "Bad $v not in $model"
+end
+
+@test implements(MyVect([1,2,3]), ThSet)
+
+# this will fail unless WithModel accepts subtypes
+@test ThSet.default[MyVect([1,2,3])](1) == 1
 
 end # module

--- a/test/stdlib/FinMatrices.jl
+++ b/test/stdlib/FinMatrices.jl
@@ -20,4 +20,7 @@ using .ThCategory
 
 end
 
-end
+# Test that `impl_type` is sensitive to the `where` parameters
+@test impl_type(FinMatC{Float64}(), ThCategory, :Hom) == Matrix{Float64}
+
+end # module

--- a/test/stdlib/FinSets.jl
+++ b/test/stdlib/FinSets.jl
@@ -16,4 +16,4 @@ using .ThCategory
   @test codom([5]; context=(codom=10,)) == 10
 end
 
-end
+end # module

--- a/test/stdlib/Nothings.jl
+++ b/test/stdlib/Nothings.jl
@@ -13,4 +13,4 @@ using .ThCategory
   @test isnothing(compose(nothing, nothing))
 end
 
-end
+end # module

--- a/test/stdlib/Op.jl
+++ b/test/stdlib/Op.jl
@@ -35,5 +35,4 @@ end
   @test codom([5]) == 1
 end
 
-
 end # module

--- a/test/stdlib/SliceCategories.jl
+++ b/test/stdlib/SliceCategories.jl
@@ -2,7 +2,7 @@ module TestSliceCategories
 
 using GATlab, Test
 
-const C = SliceC{Int, Vector{Int}, FinSetC}(FinSetC(), 4)
+const C = SliceC(FinSetC(), 4)
 const MkOb = SliceOb{Int, Vector{Int}}
 
 using .ThCategory

--- a/test/syntax/TheoryInterface.jl
+++ b/test/syntax/TheoryInterface.jl
@@ -46,7 +46,8 @@ end
   @op 1 + 1
 end
 
-@test (@doc ThCMonoid.Meta.theory) isa Markdown.MD
-@test (@doc ThSet) == (@doc ThSet.Meta.theory)
+# DEPRECATED
+# @test (@doc ThCMonoid.Meta.theory) isa Markdown.MD
+# @test (@doc ThSet) == (@doc ThSet.Meta.theory)
 
 end


### PR DESCRIPTION
This PR removes the `Model` abstract type which was overly constraining (preventing one and the same `struct` from being a model of many different theories). One purpose the `Model` type served was to make it easy to see what Julia types were associated with the theory type constructors, but this functionality is now provided by `impl_type` methods which get defined by `@instance`.

This also led to an opportunity to simply model migration code, which is no longer handled convolutedly within the module of a `@theorymap` but instead is a function (which calls `eval` to create a new struct which just wraps the input model). If we start actually using model migrations and get worried about generating too many structs, it wouldn't be hard to cache the inputs to this function.

All interesting changes are in `ModelInterface.jl`. Lots of tiny changes (mostly removing `<: Model{...}` are in other files.