### PR TITLE
Allow checking if a model does NOT implement a given theory

### DIFF
--- a/src/models/ModelInterface.jl
+++ b/src/models/ModelInterface.jl
@@ -76,7 +76,7 @@ end
 If `m` implements the GATSegment referred to by `tag`, then return the
 corresponding implementation notes.
 """
-implements(m::Module, ::Type{Val{tag}}) where {tag} = nothing
+implements(m, ::Type{Val{tag}}) where {tag} = nothing
 
 implements(m, tag::ScopeTag) = implements(m, Val{tag})
 
@@ -610,9 +610,10 @@ end
 
 function implements_declaration(model_type, scope, whereparams)
   notes = ImplementationNotes(nothing)
+  m = only(methods(implements, (Any, Type{Val{1}})))
   quote
-    if !hasmethod($(GlobalRef(ModelInterface, :implements)), 
-        ($(model_type) where {$(whereparams...)}, Type{Val{$(gettag(scope))}}))
+    if $m == only(methods($(GlobalRef(ModelInterface, :implements)), 
+        ($(model_type) where {$(whereparams...)}, Type{Val{$(gettag(scope))}})))
       $(GlobalRef(ModelInterface, :implements))(
         ::$(model_type), ::Type{Val{$(gettag(scope))}}
       ) where {$(whereparams...)} = $notes

--- a/src/nonstdlib/models/Pushouts.jl
+++ b/src/nonstdlib/models/Pushouts.jl
@@ -2,8 +2,6 @@ using DataStructures, StructEquality
 
 export PushoutInt
 
-using GATlab
-
 """Data required to specify a pushout. No fancy caching."""
 @struct_hash_equal struct PushoutInt
   ob::Int

--- a/src/stdlib/derivedmodels/DerivedModels.jl
+++ b/src/stdlib/derivedmodels/DerivedModels.jl
@@ -6,7 +6,7 @@ using ...StdTheoryMaps
 using ...StdModels
 
 # Given a model of a category C, we can derive a model of Cᵒᵖ.
-OpFinSetC = migrate_model(OpCat, FinSetC())
+OpFinSetC = migrate_model(OpCat, FinSetC(), :OpFinSetCat)
 
 # Interpret `e` as `0` and `⋅` as `+`.
 IntMonoid = migrate_model(NatPlusMonoid, IntNatPlus())

--- a/src/stdlib/models/arithmetic.jl
+++ b/src/stdlib/models/arithmetic.jl
@@ -3,14 +3,14 @@ export IntNat, IntNatPlus, IntPreorder, ZRing, BoolRing
 using ...Models
 using ..StdTheories
 
-struct IntNat <: Model{Tuple{Int}} end
+struct IntNat end
 
 @instance ThNat{Int} [model::IntNat] begin
   Z() = 0
   S(n::Int) = n + 1
 end
 
-struct IntNatPlus <: Model{Tuple{Int}} end
+struct IntNatPlus end
 
 @instance ThNatPlus{Int} [model::IntNatPlus] begin
   Z() = 0
@@ -18,7 +18,7 @@ struct IntNatPlus <: Model{Tuple{Int}} end
   +(x::Int, y::Int) = x + y
 end
 
-struct IntPreorder <: Model{Tuple{Int, Tuple{Int,Int}}} end
+struct IntPreorder end
 
 @instance ThPreorder{Int, Tuple{Int,Int}} [model::IntPreorder] begin
   Leq(ab::Tuple{Int,Int}, a::Int, b::Int) = a ≤ b ? ab : @fail "$(ab[1]) ≰ $(ab[2])"
@@ -30,7 +30,7 @@ struct IntPreorder <: Model{Tuple{Int, Tuple{Int,Int}}} end
   end
 end
 
-struct ZRing <: Model{Tuple{Int}} end
+struct ZRing end
 
 @instance ThRing{Int} [model::ZRing] begin
   zero() = 0

--- a/src/stdlib/models/finmatrices.jl
+++ b/src/stdlib/models/finmatrices.jl
@@ -3,8 +3,7 @@ export FinMatC
 using ...Models
 using ..StdTheories
 
-struct FinMatC{T<:Number} <: Model{Tuple{T}}
-end
+struct FinMatC{T <: Number} end
 
 @instance ThCategory{Int, Matrix{T}} [model::FinMatC{T}] where {T} begin
   Ob(n::Int) = n >= 0 ? n : @fail "expected nonnegative integer"

--- a/src/stdlib/models/finsets.jl
+++ b/src/stdlib/models/finsets.jl
@@ -3,8 +3,7 @@ export FinSetC
 using ...Models
 using ..StdTheories
 
-struct FinSetC <: Model{Tuple{Int, Vector{Int}}}
-end
+struct FinSetC end
 
 @instance ThCategory{Int, Vector{Int}} [model::FinSetC] begin
   Ob(x::Int) = x >= 0 ? x : @fail "expected nonnegative integer"

--- a/src/stdlib/models/gats.jl
+++ b/src/stdlib/models/gats.jl
@@ -4,10 +4,7 @@ using ...Models
 using ...Syntax
 using ..StdTheories
 
-using GATlab, GATlab.Models
-
-struct GATC <: Model{Tuple{GAT, AbsTheoryMap}}
-end
+struct GATC end
 
 @instance ThCategory{GAT, AbsTheoryMap} [model::GATC] begin
   id(x::GAT) = IdTheoryMap(x)

--- a/src/stdlib/models/nothings.jl
+++ b/src/stdlib/models/nothings.jl
@@ -2,8 +2,7 @@ export NothingC
 
 using ...Models, ..StdTheories
 
-struct NothingC <: Model{Tuple{Nothing, Nothing}}
-end
+struct NothingC end
 
 @instance ThCategory{Nothing, Nothing} [model::NothingC] begin
   Ob(::Nothing) = nothing

--- a/src/stdlib/models/op.jl
+++ b/src/stdlib/models/op.jl
@@ -10,8 +10,17 @@ using ...Models
 using ..StdTheories
 using StructEquality
 
-@struct_hash_equal struct OpC{ObT, HomT, C<:Model{Tuple{ObT, HomT}}} <: Model{Tuple{ObT, HomT}}
-  cat::C
+# TODO when we implement custom structs for models of a particular theory, we 
+# can use that rather than a generic "C" for which we then have to check 
+# whether it implements the theory.
+
+@struct_hash_equal struct OpC{ObT, HomT, C}
+  cat::C 
+  function OpC(c::C) where C 
+    obtype = impl_type(c, ThCategory, :Ob)
+    homtype = impl_type(c, ThCategory, :Hom)
+    implements(c, ThCategory) ? new{obtype, homtype, C}(c) : error("bad")
+  end
 end
 
 op(c) = OpC(c)

--- a/src/stdlib/models/slicecategories.jl
+++ b/src/stdlib/models/slicecategories.jl
@@ -9,13 +9,15 @@ using StructEquality
   hom::HomT
 end
 
-@struct_hash_equal struct SliceC{ObT, HomT, C<:Model{Tuple{ObT, HomT}}} <: Model{Tuple{SliceOb{ObT, HomT}, HomT}}
+@struct_hash_equal struct SliceC{ObT, HomT, C}
   cat::C
   over::ObT
-  # function SliceC(cat, over)
-  #   implements(cat, ThCategory)
-  #   new(cat, Ob[cat](over))
-  # end
+  function SliceC(cat::C, over) where C
+    implements(cat, ThCategory) || error("Bad cat $cat")
+    obtype = impl_type(cat, ThCategory, :Ob)
+    homtype = impl_type(cat, ThCategory, :Hom)
+    new{obtype, homtype, C}(cat, ThCategory.Ob[cat](over))
+  end
 end
 
 using .ThCategory

--- a/src/syntax/GATs.jl
+++ b/src/syntax/GATs.jl
@@ -14,7 +14,7 @@ export Constant, AlgTerm, AlgType, AlgAST,
 using ..Scopes
 import ..ExprInterop: fromexpr, toexpr
 
-import ..Scopes: retag, rename, reident
+import ..Scopes: retag, rename, reident, gettag
 
 import AlgebraicInterfaces: equations
 

--- a/src/syntax/TheoryInterface.jl
+++ b/src/syntax/TheoryInterface.jl
@@ -1,14 +1,11 @@
 module TheoryInterface
-export @theory, @signature, Model, invoke_term
+export @theory, @signature, invoke_term
 
 using ..Scopes, ..GATs, ..ExprInterop, GATlab.Util
-# using GATlab.Util
 
 using MLStyle, StructEquality, Markdown
 
-abstract type Model{Tup <: Tuple} end
-
-@struct_hash_equal struct WithModel{M <: Model}
+@struct_hash_equal struct WithModel{M}
   model::M
 end
 
@@ -191,8 +188,8 @@ function juliadeclaration(name::Symbol)
   quote
     function $name end
 
-    if Base.isempty(Base.methods(Base.getindex, [typeof($name), $(GlobalRef(TheoryInterface, :Model))]))
-      function Base.getindex(::typeof($name), m::$(GlobalRef(TheoryInterface, :Model)))
+    if Base.isempty(Base.methods(Base.getindex, [typeof($name), Any]))
+      function Base.getindex(::typeof($name), m::Any) 
         (args...; context=nothing) -> $name($(GlobalRef(TheoryInterface, :WithModel))(m), args...; context)
       end
     end

--- a/src/syntax/TheoryMaps.jl
+++ b/src/syntax/TheoryMaps.jl
@@ -402,8 +402,6 @@ macro theorymap(head, body)
   codom = macroexpand(__module__, :($codomname.Meta.@theory))
   tmap = fromexpr(dom, codom, body, TheoryMap)
 
-  mig = migrator(tmap, dommod, codommod, dom, codom)
-
   esc(
     Expr(
       :toplevel,
@@ -413,8 +411,6 @@ macro theorymap(head, body)
           macro map() $tmap end
           macro dom() $dommod end
           macro codom() $codommod end
-
-          $mig
         end
       ),
       :(Core.@__doc__ $(name)),

--- a/src/syntax/gats/gat.jl
+++ b/src/syntax/gats/gat.jl
@@ -379,3 +379,5 @@ end
 
 """Get all structs in a theory"""
 structs(t::GAT) = AlgStruct[getvalue(t[methodof(s)]) for s in struct_sorts(t)]
+
+gettag(T::GAT) = gettag(T.segments.scopes[end])

--- a/test/models/ModelInterface.jl
+++ b/test/models/ModelInterface.jl
@@ -53,6 +53,7 @@ end
 @test_throws ErrorException codom[FinSetC()]([1,2,3])
 
 @test implements(FinSetC(), ThCategory)
+@test !implements(FinSetC(), ThNatPlus)
 
 # Todo: get things working where Ob and Hom are the same type (i.e. binding dict not monic)
 struct TypedFinSetC

--- a/test/models/ModelInterface.jl
+++ b/test/models/ModelInterface.jl
@@ -1,11 +1,8 @@
 module TestModelInterface 
 
-using GATlab
-using Test
-using StructEquality
+using GATlab, Test, StructEquality
 
-@struct_hash_equal struct FinSetC <: Model{Tuple{Int, Vector{Int}}}
-end
+@struct_hash_equal struct FinSetC end
 
 @instance ThCategory{Int, Vector{Int}} [model::FinSetC] begin
   # check f is Hom: n -> m
@@ -58,7 +55,7 @@ end
 @test implements(FinSetC(), ThCategory)
 
 # Todo: get things working where Ob and Hom are the same type (i.e. binding dict not monic)
-struct TypedFinSetC <: Model{Tuple{Vector{Int}, Vector{Int}}}
+struct TypedFinSetC
   ntypes::Int
 end
 
@@ -199,7 +196,7 @@ end
 #################################
  
 """ Assume this implements Base.iterate """
-abstract type MyAbsIter{V} <: Model{Tuple{V}} end
+abstract type MyAbsIter{V} end
 
 struct MyVect{V} <: MyAbsIter{V}
   v::Vector{V}

--- a/test/stdlib/FinMatrices.jl
+++ b/test/stdlib/FinMatrices.jl
@@ -20,4 +20,7 @@ using .ThCategory
 
 end
 
-end
+# Test that `impl_type` is sensitive to the `where` parameters
+@test impl_type(FinMatC{Float64}(), ThCategory, :Hom) == Matrix{Float64}
+
+end # module

--- a/test/stdlib/FinSets.jl
+++ b/test/stdlib/FinSets.jl
@@ -16,4 +16,4 @@ using .ThCategory
   @test codom([5]; context=(codom=10,)) == 10
 end
 
-end
+end # module

--- a/test/stdlib/Nothings.jl
+++ b/test/stdlib/Nothings.jl
@@ -13,4 +13,4 @@ using .ThCategory
   @test isnothing(compose(nothing, nothing))
 end
 
-end
+end # module

--- a/test/stdlib/Op.jl
+++ b/test/stdlib/Op.jl
@@ -35,5 +35,4 @@ end
   @test codom([5]) == 1
 end
 
-
 end # module

--- a/test/stdlib/SliceCategories.jl
+++ b/test/stdlib/SliceCategories.jl
@@ -2,7 +2,7 @@ module TestSliceCategories
 
 using GATlab, Test
 
-const C = SliceC{Int, Vector{Int}, FinSetC}(FinSetC(), 4)
+const C = SliceC(FinSetC(), 4)
 const MkOb = SliceOb{Int, Vector{Int}}
 
 using .ThCategory


### PR DESCRIPTION
Addresses https://github.com/AlgebraicJulia/GATlab.jl/issues/174

This fixes the typo of the catch-all case, i.e. 

```julia
implements(m::Module,::Type{Val{tag}}) where tag = nothing
``` 

We replace `Module` with `Any`. 

However, the way we check whether or not an `@instance` call needs to define a new instance method is whether or not there are *any* methods `implements(::ModelType, Val{specific_tag})`. So now there is one that is always there by default. 

One would think, then, that the correct way to fix this logic is to check whether or not there is exactly *one* method, rather than zero like before. However, because of how `methods` works, once some earlier `@instance` call has already defined the more specific `implements` method (which returns not `nothing`), it's not that there are now *two* methods but there still is just one (it's the newer, more specific one). So the logic check is to simply check whether or not the `only` method is equal to the catch-all case.