### PR TITLE
Wrapper struct for models of a theory

### DIFF
--- a/src/nonstdlib/module.jl
+++ b/src/nonstdlib/module.jl
@@ -4,12 +4,8 @@ using Reexport
 
 include("theories/module.jl")
 include("models/module.jl")
-# include("theorymaps/module.jl")
-# include("derivedmodels/module.jl")
 
 @reexport using .NonStdTheories
 @reexport using .NonStdModels
-# @reexport using .StdTheoryMaps
-# @reexport using .StdDerivedModels
 
 end

--- a/src/stdlib/theories/algebra.jl
+++ b/src/stdlib/theories/algebra.jl
@@ -1,6 +1,9 @@
-export ThEmpty, ThSet, ThMagma, ThSemiGroup, ThMonoid, ThGroup, ThCMonoid, ThAb, ThSemiRing, ThRing, ThCommRing, ThDiffRing, ThBooleanRing, ThDivisionRing, ThCRig, ThElementary, ThPreorder, ThLeftModule, ThRightModule, ThModule, ThCommRModule
+export ThEmpty, ThSet, ThMagma, ThSemiGroup, ThMonoid, ThGroup, ThCMonoid, ThAb, 
+       ThSemiRing, ThRing, ThCommRing, ThDiffRing, ThBooleanRing, ThDivisionRing, 
+       ThCRig, ThElementary, ThPreorder, ThLeftModule, ThRightModule, ThModule, 
+       ThCommRModule
 
-import Base: +, *, zero, one, -
+import Base: +, *, zero, one, -, inv
 
 @theory ThEmpty begin
 end

--- a/src/syntax/Scopes.jl
+++ b/src/syntax/Scopes.jl
@@ -849,7 +849,11 @@ hastag(hsl::HasScopeList, t::ScopeTag) =
 hasname(hsl::HasScopeList, name::Symbol) =
   haskey(getscopelist(hsl).namelookup, name)
 
-getidents(hsl::HasScopeList; kw...) = vcat(getidents.(getscopelist(hsl); kw...)...)
+getidents(hsl::HasScopeList; kw...) = 
+  vcat(getidents.(getscopelist(hsl); kw...)...)
+
+identvalues(hsl::HasScopeList) = 
+  vcat(identvalues.(getscopelist(hsl))...)
 
 alltags(hsl::HasScopeList) = Set(gettag.(getscopelist(hsl).scopes))
 

--- a/src/syntax/TheoryMaps.jl
+++ b/src/syntax/TheoryMaps.jl
@@ -418,7 +418,4 @@ macro theorymap(head, body)
   )
 end
 
-function migrator end
-
-
 end # module

--- a/src/syntax/gats/gat.jl
+++ b/src/syntax/gats/gat.jl
@@ -36,6 +36,8 @@ fancier.
   bysignature::Dict{AlgSorts, Ident}
 end
 
+Base.iterate(m::MethodResolver, i...) = iterate(m.bysignature, i...)
+
 function MethodResolver()
   MethodResolver(Dict{AlgSorts, Ident}())
 end

--- a/test/models/SymbolicModels.jl
+++ b/test/models/SymbolicModels.jl
@@ -19,6 +19,15 @@ f = FreeCategory.Hom{:generator}([:f], [x, y])
 @test ThCategory.id(x) isa HomExpr{:id}
 @test ThCategory.compose(ThCategory.id(x), f) == f
 
+M = FreeCategory.Meta.M
+@test M isa Dispatch
+@test implements(M, ThCategory)
+@test !implements(M, ThNatPlus)
+@test impl_type(M, ThCategory, :Ob) == FreeCategory.Ob
+@test impl_type(M, ThCategory, :Hom) == FreeCategory.Hom
+@test ThCategory.id[M](x) isa HomExpr{:id}
+@test ThCategory.compose[M](ThCategory.id(x), f) == f
+
 # Monoid
 ########
 


### PR DESCRIPTION
This addresses https://github.com/AlgebraicJulia/GATlab.jl/issues/178

One can declare that `Foo` is a single-field struct which wraps models of `ThCategory` via `ThCategory.Meta.@wrapper Foo`. This type can be a subtype of an abstract type too: `ThCategory.Meta.@wrapper Foo <: MyAbsType`.

We may also want to generate a wrapper struct which has type parameters for the associated Julia types, so `ThCategory.Meta.@typed_wrapper Foo` means that `Foo(FinCatC()) isa Foo{Int,Vector{Int}}`

It's unclear if we should just have the typed version and, if one doesn't need to use the type parameters, one can ignore them.