### PR TITLE
Don't reexport StdLib

### DIFF
--- a/src/GATlab.jl
+++ b/src/GATlab.jl
@@ -6,12 +6,13 @@ using Reexport
 include("util/module.jl")
 include("syntax/module.jl")
 include("models/module.jl")
+
+# don't reexport these
 include("stdlib/module.jl")
-include("nonstdlib/module.jl") # don't reexport this
+include("nonstdlib/module.jl")
 
 @reexport using .Util
 @reexport using .Syntax
 @reexport using .Models
-@reexport using .Stdlib
 
 end # module GATlab

--- a/test/models/ModelInterface.jl
+++ b/test/models/ModelInterface.jl
@@ -1,6 +1,6 @@
 module TestModelInterface 
 
-using GATlab, Test, StructEquality
+using GATlab, GATlab.Stdlib, Test, StructEquality
 
 @struct_hash_equal struct FinSetC end
 

--- a/test/models/Presentations.jl
+++ b/test/models/Presentations.jl
@@ -1,7 +1,6 @@
 module TestPresentations
 
-using Test
-using GATlab
+using Test, GATlab, GATlab.Stdlib
 
 presentation_theory(::Presentation{Theory}) where Theory = Theory
 

--- a/test/models/SymbolicModels.jl
+++ b/test/models/SymbolicModels.jl
@@ -1,6 +1,6 @@
 module TestSymbolicModels
 
-using GATlab, Test
+using GATlab, GATlab.Stdlib, Test
 
 abstract type CategoryExpr{T} <: GATExpr{T} end
 
@@ -130,7 +130,7 @@ end
 
 module CatTests
 
-using GATlab, Test
+using GATlab, GATlab.Stdlib, Test
 
 @symbolic_model FreeCategory{GATExpr, GATExpr} ThCategory begin
   compose(f::Hom, g::Hom) = associate(new(f,g))

--- a/test/nonstdlib/Pushouts.jl
+++ b/test/nonstdlib/Pushouts.jl
@@ -1,7 +1,5 @@
 
-using Test
-using GATlab
-using GATlab.NonStdlib
+using Test, GATlab, GATlab.Stdlib, GATlab.NonStdlib
 
 using .ThPushout
 

--- a/test/stdlib/Arithmetic.jl
+++ b/test/stdlib/Arithmetic.jl
@@ -1,7 +1,6 @@
 module TestArithmetic 
 
-using GATlab
-using Test
+using GATlab, GATlab.Stdlib, Test
 
 # Peano arithmetic
 # -----------------------------

--- a/test/stdlib/FinMatrices.jl
+++ b/test/stdlib/FinMatrices.jl
@@ -1,6 +1,6 @@
 module TestFinMatrices
 
-using GATlab, Test
+using GATlab, GATlab.Stdlib, Test
 
 using .ThCategory
 

--- a/test/stdlib/FinSets.jl
+++ b/test/stdlib/FinSets.jl
@@ -1,6 +1,6 @@
 module TestFinSets
 
-using GATlab, Test
+using GATlab, GATlab.Stdlib, Test
 
 using .ThCategory
 

--- a/test/stdlib/GATs.jl
+++ b/test/stdlib/GATs.jl
@@ -1,6 +1,6 @@
 module TestGATs
 
-using GATlab, Test
+using GATlab, GATlab.Stdlib, Test
 
 using .ThCategory
 

--- a/test/stdlib/Nothings.jl
+++ b/test/stdlib/Nothings.jl
@@ -1,6 +1,6 @@
 module TestNothings
 
-using Test, GATlab
+using Test, GATlab, GATlab.Stdlib
 
 using .ThCategory
 

--- a/test/stdlib/Op.jl
+++ b/test/stdlib/Op.jl
@@ -1,7 +1,7 @@
 """Same as FinSetC tests but with all doms/codoms reversed"""
 module TestOp
 
-using GATlab, Test
+using GATlab, GATlab.Stdlib, Test
 
 using .ThCategory
 

--- a/test/stdlib/SliceCategories.jl
+++ b/test/stdlib/SliceCategories.jl
@@ -1,6 +1,6 @@
 module TestSliceCategories
 
-using GATlab, Test
+using GATlab, GATlab.Stdlib, Test
 
 const C = SliceC(FinSetC(), 4)
 const MkOb = SliceOb{Int, Vector{Int}}

--- a/test/syntax/GATContexts.jl
+++ b/test/syntax/GATContexts.jl
@@ -1,7 +1,7 @@
 module TestGATContexts
 
-using GATlab
-using Test
+using GATlab, GATlab.Stdlib, Test
+
 T = ThCategory.Meta.theory
 ctx = GATContext(T)
 tscope = fromexpr(

--- a/test/syntax/GATs.jl
+++ b/test/syntax/GATs.jl
@@ -1,6 +1,6 @@
 module TestGATs 
 
-using GATlab, Test
+using GATlab, GATlab.Stdlib, Test
 
 
 # GAT ASTs

--- a/test/syntax/TheoryMaps.jl
+++ b/test/syntax/TheoryMaps.jl
@@ -1,7 +1,6 @@
 module TestTheoryMaps 
 
-using GATlab
-using Test
+using GATlab, GATlab.Stdlib, Test
 
 # Set up 
 ########


### PR DESCRIPTION
GATlab standard library should be opt-in rather than exported by default, as it's often the case that important names (e.g. `FinSetC`, `op`) are claimed which might require alternative / more serious implementations elsewhere, such as Catlab. 