### PR TITLE
Remove `@fail`

### DIFF
--- a/src/stdlib/models/arithmetic.jl
+++ b/src/stdlib/models/arithmetic.jl
@@ -21,7 +21,7 @@ end
 struct IntPreorder end
 
 @instance ThPreorder{Int, Tuple{Int,Int}} [model::IntPreorder] begin
-  Leq(ab::Tuple{Int,Int}, a::Int, b::Int) = a ≤ b ? ab : @fail "$(ab[1]) ≰ $(ab[2])"
+  Leq(ab::Tuple{Int,Int}, a::Int, b::Int) = a ≤ b ? ab : error("$(ab[1]) ≰ $(ab[2])")
   refl(i::Int) = (i, i)
   trans(ab::Tuple{Int,Int}, bc::Tuple{Int,Int}) = if ab[2] == bc[1] 
     (ab[1], bc[2])

--- a/src/stdlib/models/finmatrices.jl
+++ b/src/stdlib/models/finmatrices.jl
@@ -6,9 +6,9 @@ using ..StdTheories
 struct FinMatC{T <: Number} end
 
 @instance ThCategory{Int, Matrix{T}} [model::FinMatC{T}] where {T} begin
-  Ob(n::Int) = n >= 0 ? n : @fail "expected nonnegative integer"
+  Ob(n::Int) = n >= 0 ? n : error("expected nonnegative integer")
   Hom(A::Matrix{T}, n::Int, m::Int) =
-    size(A) == (n,m) ? A : @fail "expected dimensions to be $((n,m))"
+    size(A) == (n,m) ? A : error("expected dimensions to be $((n,m))")
 
   id(n::Int) = T[T(i == j) for i in 1:n, j in 1:n]
   compose(A::Matrix{T}, B::Matrix{T}) = A * B

--- a/src/stdlib/models/finsets.jl
+++ b/src/stdlib/models/finsets.jl
@@ -6,18 +6,18 @@ using ..StdTheories
 struct FinSetC end
 
 @instance ThCategory{Int, Vector{Int}} [model::FinSetC] begin
-  Ob(x::Int) = x >= 0 ? x : @fail "expected nonnegative integer"
+  Ob(x::Int) = x >= 0 ? x : error("expected nonnegative integer")
 
   function Hom(f::Vector{Int}, n::Int, m::Int)
     if length(f) == n
       for i in 1:n
         if f[i] ∉ 1:m
-          @fail "index not in codomain: $i"
+          error("index not in codomain: $i")
         end
       end
       f
     else
-      @fail "length of morphism does not match domain: $(length(f)) != $m"
+      error("length of morphism does not match domain: $(length(f)) != $m")
     end
   end
 

--- a/src/stdlib/models/slicecategories.jl
+++ b/src/stdlib/models/slicecategories.jl
@@ -27,12 +27,12 @@ using .ThCategory
     try
       Ob[model.cat](x.ob)
     catch e
-      @fail ("ob is not valid", e)
+      error("ob is not valid", e)
     end
     try
       Hom[model.cat](x.hom, x.ob, model.over)
     catch e
-      @fail ("hom is not valid", e)
+      error("hom is not valid", e)
     end
     x
   end
@@ -43,10 +43,10 @@ using .ThCategory
     try
       Hom[model.cat](f, x.ob, y.ob)
     catch e
-      @fail ("morphism is not valid in base category", e)
+      error("morphism is not valid in base category", e)
     end
     compose[model.cat](f, y.hom; context=(a=x.ob, b=y.ob, c=model.over)) == x.hom ||
-      @fail "commutativity of triangle does not hold"
+      error("commutativity of triangle does not hold")
     f
   end
 

--- a/test/models/ModelInterface.jl
+++ b/test/models/ModelInterface.jl
@@ -10,12 +10,12 @@ using GATlab, GATlab.Stdlib, Test, StructEquality
     if length(f) == n
       for i in 1:n
         if f[i] ∉ 1:m
-          @fail "index not in codomain: $i"
+          error("index not in codomain: $i")
         end
       end
       f
     else
-      @fail "length of morphism does not match domain: $(length(f)) != $m"
+      error("length of morphism does not match domain: $(length(f)) != $m")
     end
   end
 
@@ -29,22 +29,10 @@ using .ThCategory
 
 @test Ob[FinSetC()](-1) == -1
 @test Hom[FinSetC()]([1,2,3], 3, 3) == [1,2,3]
-@test_throws TypeCheckFail Hom[FinSetC()]([1,2,3], 3, 2)
+@test_throws ErrorException Hom[FinSetC()]([1,2,3], 3, 2)
 
-try
-  ThCategory.Hom[FinSetC()]([1,2,3], 3, 2)
-catch e
-  @test e.model == FinSetC()
-  @test e.theory == ThCategory.Meta.theory
-  @test e.type == ident(ThCategory.Meta.theory; name=:Hom)
-  @test e.val == [1, 2, 3]
-  @test e.args == [3, 2]
-  @test e.reason == "index not in codomain: 3"
-  @test sprint(showerror, e) isa String
-end
-
-@test_throws TypeCheckFail Hom[FinSetC()]([1,2,3], 3, 2)
-@test_throws TypeCheckFail Hom[FinSetC()]([1,2,3], 2, 3)
+@test_throws ErrorException Hom[FinSetC()]([1,2,3], 3, 2)
+@test_throws ErrorException Hom[FinSetC()]([1,2,3], 2, 3)
 @test compose[FinSetC()]([1,3,2], [1,3,2]) == [1,2,3]
 
 @test id[FinSetC()](2) == [1,2]
@@ -90,11 +78,11 @@ end
 end 
 
 @instance ThCategory{FinSet, FinFunction} begin
-  Ob(x::FinSet) = x.n ≥ 0 ? x : @fail "expected nonnegative integer"
+  Ob(x::FinSet) = x.n ≥ 0 ? x : error("expected nonnegative integer")
 
   function Hom(f::FinFunction, x::FinSet, y::FinSet)
-    dom(f) == x || @fail "domain mismatch"
-    codom(f) == y || @fail "codomain mismatch"
+    dom(f) == x || error("domain mismatch")
+    codom(f) == y || error("codomain mismatch")
     f
   end
 
@@ -118,7 +106,7 @@ g = FinFunction([1,1,1],B,A)
 @test Hom(f, A, B) == f
 # TODO:
 # @test Hom([2,3], A, B) == f
-@test_throws TypeCheckFail Hom(f, A, A)
+@test_throws ErrorException Hom(f, A, A)
 
 @withmodel FinSetC() (mcompose, id) begin
   @test mcompose(id(2), id(2); context=(;B₁=2)) == id(4)
@@ -206,7 +194,7 @@ end
 Base.iterate(m::MyVect, i...) = iterate(m.v, i...)
 
 @instance ThSet{V} [model::MyAbsIter{V}] where V begin 
-  default(v::V) = v ∈ model ? v : @fail "Bad $v not in $model"
+  default(v::V) = v ∈ model ? v : error("Bad $v not in $model")
 end
 
 @test implements(MyVect([1,2,3]), ThSet)

--- a/test/stdlib/Arithmetic.jl
+++ b/test/stdlib/Arithmetic.jl
@@ -33,7 +33,7 @@ using .ThPreorder
 
 @withmodel IntPreorder() (Leq, refl, trans) begin
   @test trans((1,3), (3,5)) == (1,5)  
-  @test_throws TypeCheckFail Leq((5,3), 5, 3)
+  @test_throws ErrorException Leq((5,3), 5, 3)
   @test refl(2) == (2,2)
 end
 
@@ -43,7 +43,7 @@ using .ThCategory
 
 @withmodel IntPreorderCat (Hom, id, compose) begin
   @test compose((1,3), (3,5)) == (1,5)
-  @test_throws TypeCheckFail Hom((5,3), 5, 3)
+  @test_throws ErrorException Hom((5,3), 5, 3)
   @test_throws ErrorException compose((1,2), (3,5))
   @test id(2) == (2,2)
 end

--- a/test/stdlib/FinMatrices.jl
+++ b/test/stdlib/FinMatrices.jl
@@ -6,9 +6,9 @@ using .ThCategory
 
 @withmodel FinMatC{Float64}() (Ob, Hom, id, compose, dom, codom) begin
   @test Ob(0) == 0
-  @test_throws TypeCheckFail Ob(-1)
+  @test_throws ErrorException Ob(-1)
   @test Hom([1. 0; -1 1], 2, 2) == [1. 0; -1 1]
-  @test_throws TypeCheckFail Hom([1. 0], 2, 2)
+  @test_throws ErrorException Hom([1. 0], 2, 2)
   @test_throws MethodError Hom([1 0; 0 1], 2, 2)
 
   @test id(2) == [1. 0; 0 1]

--- a/test/stdlib/FinSets.jl
+++ b/test/stdlib/FinSets.jl
@@ -6,8 +6,8 @@ using .ThCategory
 
 @withmodel FinSetC() (Ob, Hom, id, compose, dom, codom) begin
   @test Ob(0) == 0
-  @test_throws TypeCheckFail Ob(-1)
-  @test_throws TypeCheckFail Hom([1,5,2], 3, 4)
+  @test_throws ErrorException Ob(-1)
+  @test_throws ErrorException Hom([1,5,2], 3, 4)
   @test Hom(Int[], 0, 4) == Int[]
 
   @test id(2) == [1,2]

--- a/test/stdlib/Op.jl
+++ b/test/stdlib/Op.jl
@@ -10,8 +10,8 @@ using .ThCategory
 
 @withmodel op(FinSetC()) (Ob, Hom, id, compose, dom, codom) begin
   @test Ob(0) == 0
-  @test_throws TypeCheckFail Ob(-1)
-  @test_throws TypeCheckFail Hom([1,5,2], 4, 3)
+  @test_throws ErrorException Ob(-1)
+  @test_throws ErrorException Hom([1,5,2], 4, 3)
   @test Hom(Int[], 4, 0) == Int[]
 
   @test id(2) == [1,2]
@@ -26,8 +26,8 @@ end
 
 @withmodel OpFinSetC (Ob, Hom, id, compose, dom, codom) begin
   @test Ob(0) == 0
-  @test_throws TypeCheckFail Ob(-1)
-  @test_throws TypeCheckFail Hom([1,5,2], 4, 3)
+  @test_throws ErrorException Ob(-1)
+  @test_throws ErrorException Hom([1,5,2], 4, 3)
   @test Hom(Int[], 4, 0) == Int[]
 
   @test id(2) == [1,2]

--- a/test/stdlib/SliceCategories.jl
+++ b/test/stdlib/SliceCategories.jl
@@ -9,12 +9,12 @@ using .ThCategory
 
 @withmodel C (Ob, Hom, id, compose) begin
   @test Ob(MkOb(3, [1,3,2])) == MkOb(3, [1,3,2])
-  @test_throws TypeCheckFail Ob(MkOb(-1, [1,3,2]))
-  @test_throws TypeCheckFail Ob(MkOb(3, [1,3,2,4]))
-  @test_throws TypeCheckFail Ob(MkOb(3, [1,3,9]))
+  @test_throws ErrorException Ob(MkOb(-1, [1,3,2]))
+  @test_throws ErrorException Ob(MkOb(3, [1,3,2,4]))
+  @test_throws ErrorException Ob(MkOb(3, [1,3,9]))
   @test Hom([1,2,2], MkOb(3, [1,3,3]), MkOb(2, [1,3])) == [1,2,2]
-  @test_throws TypeCheckFail Hom([1,2,2], MkOb(3, [1,2,3]), MkOb(2, [1,3]))
-  @test_throws TypeCheckFail Hom([1,2,4], MkOb(3, [1,2,3]), MkOb(2, [1,3]))
+  @test_throws ErrorException Hom([1,2,2], MkOb(3, [1,2,3]), MkOb(2, [1,3]))
+  @test_throws ErrorException Hom([1,2,4], MkOb(3, [1,2,3]), MkOb(2, [1,3]))
   @test id(MkOb(3,[1,3,2])) == compose([1,3,2],[1,3,2])
 end
 


### PR DESCRIPTION
This is a partial step towards moving away from static typechecking of instances (we will be dynamically checking whether a model implements a theory in the future). The `@fail` macro was supposed to be helpful way to make getting the context of an error in the validation methods (overloads of the names of type constructors). It required some macro + closure trickery that's ultimately too difficult to maintain while making other required changes to GATlab for the Catlab refactor.