### PR TITLE
Runtime checking for whether a model implements a theory, special distinguished models for each theory

### DIFF
--- a/docs/src/concepts/models.md
+++ b/docs/src/concepts/models.md
@@ -1,6 +1,6 @@
 # Models and instances
 
-A *model* is any julia value `m` that satisfies `m :: Model`. A model may *implement* one or more theories; to check if a model `m` is implements a theory `Th`, one can run `implements(m, Th)`, which returns `nothing` if `m` does not implement `Th`, and returns an `ImplementationNotes` struct if `m` does implement `Th`.
+A *model* is any julia value `m` that satisfies `m :: Model`. A model may *implement* one or more theories; to check if a model `m` is implements a theory `Th`, one can run `implements(m, Th)::Bool`, to check if `m` implements all operations in `Th`.
 
 When a model `m` implements `Th`, the following methods should be defined.
 

--- a/src/models/SpecialModels.jl
+++ b/src/models/SpecialModels.jl
@@ -1,0 +1,80 @@
+module SpecialModels
+export Dispatch, InitialModel, TerminalModel, InitialModel′, TerminalModel′
+
+using ...Syntax: Ident, GAT, AlgSort, hastag, methodof, ident
+using ...Syntax.TheoryInterface: Dispatch, InitialModel′, TerminalModel′
+import ...Syntax.TheoryInterface: implements, impl_type 
+import ..ModelInterface: _implements
+
+
+# Public constants
+##################
+""" The unique term of type `InitialModel′` """
+const InitialModel = InitialModel′()
+
+""" The unique term of type `TerminalModel′` """
+const TerminalModel = TerminalModel′()
+
+# Accessing Dispatch
+####################
+
+Base.haskey(d::Dispatch, k::AlgSort) = haskey(d.jltypes, k) 
+
+Base.getindex(d::Dispatch, a::AlgSort)::Type = d.jltypes[a]
+
+function Base.getindex(d::Dispatch, x::Ident)::Type
+  for (k, v) in d.jltypes
+    methodof(k) == x && return v
+  end
+  throw(KeyError(x))
+end
+
+# Implements
+#############
+
+function implements(::Dispatch, theory_mod::Module, name::Symbol, types=nothing) 
+  if isnothing(types)
+    !isempty(methods(getfield(theory_mod, name))) # there exists *some* method
+  else 
+    hasmethod(getfield(theory_mod, name), types) # must be methods with these types
+  end
+end 
+
+function _implements(::Dispatch, theory::Module, name::Symbol, types::Vector{<:Type}) 
+  f = getfield(theory, name)
+  any(==(Union{}), types) && return true # no such methods (Julia 1.10 bug)
+  hasmethod(f, Tuple{types...})
+end
+
+function implements(::InitialModel′, ::Module, ::Symbol, types=nothing) 
+  isnothing(types) || all(==(Union{}), types)
+end
+
+_implements(::InitialModel′, ::Module, ::Symbol, types::Vector{<:Type}) =
+  all(==(Union{}), types)
+
+function implements(::TerminalModel′, ::Module, ::Symbol, types=nothing) 
+  isnothing(types) || all(==(Nothing), types)
+end
+
+_implements(::TerminalModel′, ::Module, ::Symbol, types::Vector{<:Type}) =
+  all(==(Nothing), types)
+
+
+# Impl Type
+###########
+
+function impl_type(m::Dispatch, mod::Module, name::Symbol)
+  x = ident(mod.Meta.theory; name)
+  impl_type(m, last(only(mod.Meta.theory.resolvers[x])))
+end
+
+impl_type(d::Dispatch, x::Ident) = d[x]
+
+
+impl_type(::InitialModel′, ::Ident) = Union{}
+
+impl_type(::TerminalModel′, ::Ident) = Nothing
+
+
+end # module

--- a/src/models/module.jl
+++ b/src/models/module.jl
@@ -6,10 +6,12 @@ include("ModelInterface.jl")
 include("SymbolicModels.jl")
 include("GATExprUtils.jl")
 include("Presentations.jl")
+include("SpecialModels.jl")
 
 @reexport using .ModelInterface
 @reexport using .SymbolicModels
 @reexport using .GATExprUtils
 @reexport using .Presentations
+@reexport using .SpecialModels
 
 end

--- a/src/nonstdlib/models/Pushouts.jl
+++ b/src/nonstdlib/models/Pushouts.jl
@@ -12,7 +12,6 @@ end
 using .ThPushout 
 
 @instance ThPushout{Int, Vector{Int}, PushoutInt} [model::FinSetC] begin
-  @import Ob, Hom, id, compose, dom, codom, →, ⋅
   function pushout(sp::Span; context)
     B, C = context[:d], context[:c]
     d = DataStructures.IntDisjointSets(B+C)
@@ -36,4 +35,6 @@ using .ThPushout
       error("Pushout $p is not jointly surjective")
     end
   end
+  ι₁(p::PushoutInt) = p.i1
+  ι₂(p::PushoutInt) = p.i2
 end

--- a/src/stdlib/models/op.jl
+++ b/src/stdlib/models/op.jl
@@ -17,9 +17,8 @@ using StructEquality
 @struct_hash_equal struct OpC{ObT, HomT, C}
   cat::C 
   function OpC(c::C) where C 
-    obtype = impl_type(c, ThCategory, :Ob)
-    homtype = impl_type(c, ThCategory, :Hom)
-    implements(c, ThCategory) ? new{obtype, homtype, C}(c) : error("bad")
+    types = impl_types(c, ThCategory)
+    implements(c, ThCategory, types) ? new{types..., C}(c) : error("bad")
   end
 end
 

--- a/src/stdlib/models/slicecategories.jl
+++ b/src/stdlib/models/slicecategories.jl
@@ -13,10 +13,13 @@ end
   cat::C
   over::ObT
   function SliceC(cat::C, over) where C
-    implements(cat, ThCategory) || error("Bad cat $cat")
-    obtype = impl_type(cat, ThCategory, :Ob)
-    homtype = impl_type(cat, ThCategory, :Hom)
-    new{obtype, homtype, C}(cat, ThCategory.Ob[cat](over))
+    types = try 
+      impl_types(cat, ThCategory)
+    catch e 
+      throw(e)
+    end
+    implements(cat, ThCategory, types) || error("Bad cat $cat")
+    new{types..., C}(cat, ThCategory.Ob[cat](over))
   end
 end
 

--- a/src/util/Eithers.jl
+++ b/src/util/Eithers.jl
@@ -1,11 +1,13 @@
 module Eithers
 export Either, Left, Right, isleft, isright
 
-struct Left{T}
+using StructEquality
+
+@struct_hash_equal struct Left{T}
   val::T
 end
 
-struct Right{S}
+@struct_hash_equal struct Right{S}
   val::S
 end
 

--- a/test/models/ModelInterface.jl
+++ b/test/models/ModelInterface.jl
@@ -2,9 +2,37 @@ module TestModelInterface
 
 using GATlab, GATlab.Stdlib, Test, StructEquality
 
-@struct_hash_equal struct FinSetC end
+@struct_hash_equal struct FinSetC′ end
 
-@instance ThCategory{Int, Vector{Int}} [model::FinSetC] begin
+# ThCategory models
+###################
+
+# Failures to create an instance 
+#-------------------------------
+
+# Error if we fail to implement methods
+@test_throws ErrorException @eval @instance ThCategory{Int, Vector{Int}} [model::FinSetC′] begin
+end
+
+# Error: missing `id`
+@test_throws ErrorException @eval @instance ThCategory{Int, Vector{Int}} [model::FinSetC′] begin
+  compose(f::Vector{Int}, g::Vector{Int}) = g[f]
+  dom(f::Vector{Int}) = length(f)
+end
+
+# Error if we don't implement methods with args of of right type (`id`)
+@test_throws ErrorException @eval @instance ThCategory{Int, Vector{Int}} [model::FinSetC′] begin
+  id(f::Vector{Int}) = f
+  compose(f::Vector{Int}, g::Vector{Int}) = g[f]
+  dom(f::Vector{Int}) = length(f)
+end
+
+# Actual instance
+#----------------
+
+@instance ThCategory{Int, Vector{Int}} [model::FinSetC′] begin
+Ob(i::Int) = i 
+
   # check f is Hom: n -> m
   function Hom(f::Vector{Int}, n::Int, m::Int)
     if length(f) == n
@@ -25,31 +53,53 @@ using GATlab, GATlab.Stdlib, Test, StructEquality
   dom(f::Vector{Int}) = length(f)
 end
 
+# Using the instance
+#-------------------
+
 using .ThCategory
 
-@test Ob[FinSetC()](-1) == -1
-@test Hom[FinSetC()]([1,2,3], 3, 3) == [1,2,3]
-@test_throws ErrorException Hom[FinSetC()]([1,2,3], 3, 2)
+@test Ob[FinSetC′()](-1) == -1
+@test Hom[FinSetC′()]([1,2,3], 3, 3) == [1,2,3]
+@test_throws ErrorException Hom[FinSetC′()]([1,2,3], 3, 2)
 
-@test_throws ErrorException Hom[FinSetC()]([1,2,3], 3, 2)
-@test_throws ErrorException Hom[FinSetC()]([1,2,3], 2, 3)
-@test compose[FinSetC()]([1,3,2], [1,3,2]) == [1,2,3]
+@test_throws ErrorException Hom[FinSetC′()]([1,2,3], 3, 2)
+@test_throws ErrorException Hom[FinSetC′()]([1,2,3], 2, 3)
+@test compose[FinSetC′()]([1,3,2], [1,3,2]) == [1,2,3]
 
-@test id[FinSetC()](2) == [1,2]
+@test id[FinSetC′()](2) == [1,2]
 
-@test dom[FinSetC()]([1,2,3]) == 3
-@test_throws ErrorException codom[FinSetC()]([1,2,3])
+@test dom[FinSetC′()]([1,2,3]) == 3
+@test_throws MethodError codom[FinSetC′()]([1,2,3])
 
-@test implements(FinSetC(), ThCategory)
-@test !implements(FinSetC(), ThNatPlus)
+@test implements(FinSetC′(), ThCategory, [Int,Vector{Int}])
+@test !implements(FinSetC′(), ThNatPlus, [Int])
 
-# Todo: get things working where Ob and Hom are the same type (i.e. binding dict not monic)
-@struct_hash_equal struct TypedFinSetC
-  ntypes::Int
+# Monoidal category models 
+##########################
+
+# Failures to create an instance 
+#-------------------------------
+
+# Missing `mcompose` on objects (`Int`s)
+@test_throws ErrorException @eval @instance ThStrictMonCat{Int, Vector{Int}} [model::FinSetC′] begin
+
+  mcompose(f::Vector{Int}, g::Vector{Int}; context) = [f; g .+ context.B₁]
+
+  munit() = 0
 end
 
-@instance ThStrictMonCat{Int, Vector{Int}} [model::FinSetC] begin
-  @import Ob, Hom, id, compose, dom, codom
+
+@test_throws ErrorException @eval @instance ThStrictMonCat{Int, Int} [model::FinSetC′] begin
+  mcompose(a::Int, b::Int) = a + b
+  mcompose(f::Int, g::Int; context) = f * g
+
+  munit() = 0
+end
+
+# Actual instance
+#----------------
+
+@instance ThStrictMonCat{Int, Vector{Int}} [model::FinSetC′] begin
 
   mcompose(a::Int, b::Int) = a + b
   mcompose(f::Vector{Int}, g::Vector{Int}; context) = [f; g .+ context.B₁]
@@ -57,12 +107,18 @@ end
   munit() = 0
 end
 
-@test implements(FinSetC(), ThStrictMonCat)
+@test implements(FinSetC′(), ThStrictMonCat, [Int, Vector{Int}])
+
+# Using the instance
+#-------------------
 
 using .ThStrictMonCat
 
-@test mcompose[FinSetC()](id[FinSetC()](2), id[FinSetC()](2); context=(;B₁=2)) ==
-  id[FinSetC()](4)
+@test mcompose[FinSetC′()](id[FinSetC′()](2), id[FinSetC′()](2); context=(;B₁=2)) ==
+  id[FinSetC′()](4)
+
+# Default (old-style) instance
+#-----------------------------
 
 @struct_hash_equal struct FinSet 
   n::Int 
@@ -73,7 +129,7 @@ end
   dom::FinSet 
   codom::FinSet
   function FinFunction(values::AbstractVector, dom::FinSet, codom::FinSet)
-    new(ThCategory.Hom[FinSetC()](Vector{Int}(values), dom.n, codom.n), dom, codom)
+    new(ThCategory.Hom[FinSetC′()](Vector{Int}(values), dom.n, codom.n), dom, codom)
   end
 end 
 
@@ -108,56 +164,19 @@ g = FinFunction([1,1,1],B,A)
 # @test Hom([2,3], A, B) == f
 @test_throws ErrorException Hom(f, A, A)
 
-@withmodel FinSetC() (mcompose, id) begin
+@withmodel FinSetC′() (mcompose, id) begin
   @test mcompose(id(2), id(2); context=(;B₁=2)) == id(4)
 end
 
 @test_throws MethodError id(2)
 
-@test_throws LoadError @eval @instance ThCategory{Int, Vector{Int}} [model::FinSetC] begin
-end
 
-@test_throws LoadError @eval @instance ThCategory{Int, Vector{Int}} [model::FinSetC] begin
-  compose(f::Vector{Int}, g::Vector{Int}) = g[f]
-  dom(f::Vector{Int}) = length(f)
-end
 
-@test_throws LoadError @eval @instance ThCategory{Int, Vector{Int}} [model::FinSetC] begin
-  id(f::Vector{Int}) = f
-  compose(f::Vector{Int}, g::Vector{Int}) = g[f]
-  dom(f::Vector{Int}) = length(f)
-end
-
-try
-  @eval @instance ThCategory{Int, Vector{Int}} [model::FinSetC] begin
-    id(f::Vector{Int}) = f
-    compose(f::Vector{Int}, g::Vector{Int}) = g[f]
-    dom(f::Vector{Int}) = length(f)
-  end
-catch e
-  @test e.error isa SignatureMismatchError
-  @test sprint(showerror, e.error) isa String
-end
-
-@test_throws LoadError @eval @instance ThStrictMonCat{Int, Vector{Int}} [model::FinSetC] begin
-  @import Ob, Hom, id, compose, dom, codom
-
-  mcompose(f::Vector{Int}, g::Vector{Int}; context) = [f; g .+ context.B₁]
-
-  munit() = 0
-end
-
-@test_throws LoadError @eval @instance ThStrictMonCat{Int, Int} [model::FinSetC] begin
-  @import Ob, Hom, id, compose, dom, codom
-
-  mcompose(a::Int, b::Int) = a + b
-  mcompose(f::Int, g::Int; context) = f * g
-
-  munit() = 0
-end
-
-# Test scenario where we @import a method but then extend it
+# Test scenario where we extend a method
 ############################################################
+
+# Note we no longer need to explicitly @import 
+
 @theory T1 begin 
   X::TYPE; 
   h(a::X)::X 
@@ -173,7 +192,6 @@ end
 end
 
 @instance T2{Int,Bool} begin 
-  @import X, h
   h(b::Bool) = false 
 end
 
@@ -197,36 +215,22 @@ Base.iterate(m::MyVect, i...) = iterate(m.v, i...)
   default(v::V) = v ∈ model ? v : error("Bad $v not in $model")
 end
 
-@test implements(MyVect([1,2,3]), ThSet)
+@test implements(MyVect([1,2,3]), ThSet, [Vector{Int}])
 
 # this will fail unless WithModel accepts subtypes
 @test ThSet.default[MyVect([1,2,3])](1) == 1
 
-# Test default model + dispatch model
-#####################################
-@test_throws MethodError id(2)
-
-@default_model ThCategory{Int, Vector{Int}} [model::FinSetC]
-
-d = Dispatch(ThCategory.Meta.theory, [Int, Vector{Int}])
-@test implements(d, ThCategory)
-@test !implements(d, ThNatPlus)
-@test impl_type(d, ThCategory, :Ob) == Int 
-@test impl_type(d, ThCategory, :Hom) == Vector{Int} 
-
-@test id(2) == [1,2] == ThCategory.id[d](2)
-@test compose([1,2,3], [2,1,3]) == [2,1,3]
  
 # Test wrapper structs
 ######################
 """Cat"""
-ThCategory.Meta.@wrapper Cat
+ThCategory.Meta.@wrapper Cat Any
 
-c = Cat(FinSetC());
+c = Cat(FinSetC′());
 c2 = Cat(FinMatC{Int}());
 @test_throws ErrorException Cat(MyVect([1,2,3])) # can't construct
 
-@test getvalue(c) == FinSetC()
+@test getvalue(c) == FinSetC′()
 @test impl_type(c, :Ob) == Int == impl_type(c2, :Ob)
 
 @test Ob(c, 2) == 2
@@ -238,7 +242,7 @@ end
 
 @test id2(c) == [1,2]
 @test id2(c2) == [1 0; 0 1]
-@test_throws MethodError id2(FinSetC())
+@test_throws MethodError id2(FinSetC′())
 
 abstract type MyAbsType end
 ThCategory.Meta.@wrapper Cat2 <: MyAbsType 
@@ -249,9 +253,9 @@ ThCategory.Meta.@wrapper Cat2 <: MyAbsType
 """Typed Cat"""
 ThCategory.Meta.@typed_wrapper TCat
 
-c = TCat(FinSetC())
-@test c == TCat{Int,Vector{Int}}(FinSetC())
-@test_throws ErrorException TCat{Bool,Symbol}(FinSetC()) # Ob: Int ⊄ Bool
+c = TCat(FinSetC′())
+@test c == TCat{Int,Vector{Int}}(FinSetC′())
+@test_throws ErrorException TCat{Bool,Symbol}(FinSetC′()) # Ob: Int ⊄ Bool
 @test c isa TCat{Int, Vector{Int}}
 @test id(c, 2) == [1,2]
 
@@ -259,5 +263,56 @@ c2 = TCat(FinMatC{Int}());
 @test c2 isa TCat{Int, Matrix{Int}}
 
 @test id(c2, 2) == [1 0; 0 1]
+
+# Empty tuples
+#----------------
+@instance ThCategory{Union{}, Union{}} [model::Nothing] begin
+  id(x::Union{}) = x
+  compose(f::Union{},g::Union{}) = f
+end
+
+@test TCat(nothing) isa TCat{Union{},Union{}}
+
+# Test implements 
+#################
+T = ThCategory.Meta.theory
+(_, c), (_, i) = termcons(T)
+
+implements(FinSetC′(), ThCategory, :id) # no arg type checking, just method + arity checking
+
+@test implements(FinSetC′(), ThCategory, :id, [Int])
+@test !implements(FinSetC′(), ThCategory, :id, [String])
+@test !implements(FinSetC′(), ThCategory, :id, [Any]) # is this bad?
+
+# there is a compose(::Vect,::Vect)
+@test implements(FinSetC′(), ThCategory, c, [Int, Vector{Int}]) 
+
+# no id(::String)
+@test !implements(FinSetC′(), ThCategory, i, [String, Vector{Int}]) 
+
+@test implements(FinSetC′(), ThCategory, [Int, Vector{Int}]) 
+@test !implements(FinSetC′(), ThCategory, [String, Vector{Int}]) 
+
+m = FinMatC{Float64}()
+
+@test implements(m, ThCategory, i, [Int, Matrix{Int}])
+@test implements(m, ThCategory, :id, [Int])
+@test !implements(m, ThCategory, :id, [String])
+
+
+struct Foo end
+@instance ThCategory{Union{Symbol,String}, Int} [model::Foo] begin 
+  compose(::Int,::Int) = 1
+  id(s::Symbol) = 2 
+  id(s::String) = 3
+  id(::Union{Symbol, String})= error("Unreachable")
+end
+
+@test implements(Foo(), ThCategory, [Union{Symbol,String}, Int])
+@test implements(Foo(), ThCategory, [String, Int])
+@test !implements(Foo(), ThCategory, [String, String])
+
+id[Foo()](:x) == 2
+id[Foo()]("x") == 3
 
 end # module

--- a/test/models/SpecialModels.jl
+++ b/test/models/SpecialModels.jl
@@ -1,0 +1,75 @@
+module TestSpecialModels
+
+using Test, GATlab, GATlab.Stdlib
+using .ThCategory
+
+@theory ThCat begin 
+  Ob::TYPE; Hom(dom::Ob,codom::Ob)::TYPE;
+  id(a::Ob)::Hom(a,a)
+  compose(f::Hom(a,b),g::Hom(b,c))::Hom(a,c) ⊣ [(a,b,c)::Ob]
+end
+
+using .ThCat
+
+# Test default model + dispatch model
+#####################################
+i, c = last.(termcons(ThCat.Meta.theory))
+
+@test_throws MethodError id(2)
+
+d = Dispatch(ThCat, [Int, Vector{Int}])
+
+# False: there exists no id(::String)
+@test !implements(d, ThCat, [String, Vector{Int}])
+
+# No compose(::Int,::Int) method
+@test !implements(d, ThCat, c, [Int,Vector{Int}])
+
+ThCat.compose(i::Vector{Int},j::Vector{Int}) = i
+
+# Now there is one
+@test implements(d, ThCat, c, [Int,Vector{Int}])
+
+# No compose(::Int,::Int) method
+@test !implements(Dispatch, ThCat, i, [Int,Vector{Int}])
+
+ThCat.id(i::Int) = [i]
+
+@test implements(d, ThCat, i, [Int,Vector{Int}])
+@test !implements(d, ThCat, i, [String,Vector{Int}])
+
+@test implements(d, ThCat, [Int, Vector{Int}])
+
+@test id(1) == [1] == ThCat.id[d](1)
+@test compose[d]([1],[2,3]) == [1]
+
+@test implements(d, ThCat, [Int, Vector{Int}])
+
+@test impl_type(d, ThCat, :Ob) == Int 
+@test impl_type(d, ThCat, :Hom) == Vector{Int}
+
+
+# Initial and terminal Model
+############################
+
+@test implements(InitialModel, ThCat, c, [Union{},Union{}])
+
+@test implements(TerminalModel, ThNatPlus, [Nothing])
+
+# true: all the types are `Nothing`
+@test implements(TerminalModel, ThCat, c, [Nothing,Nothing])
+
+# false: not all the types are `Nothing`
+@test !implements(TerminalModel, ThCat, c, [Nothing,Int])
+
+@test impl_type(TerminalModel, ThCat, :Hom) == Nothing
+
+
+@test impl_type(InitialModel, ThCat, :Hom) == Union{}
+
+
+@test ThCat.compose[TerminalModel](nothing, nothing) === nothing
+@test ThCat.dom[TerminalModel](nothing) === nothing
+@test_throws ErrorException dom[InitialModel](nothing)
+
+end # module

--- a/test/models/SymbolicModels.jl
+++ b/test/models/SymbolicModels.jl
@@ -21,8 +21,8 @@ f = FreeCategory.Hom{:generator}([:f], [x, y])
 
 M = FreeCategory.Meta.M
 @test M isa Dispatch
-@test implements(M, ThCategory)
-@test !implements(M, ThNatPlus)
+@test implements(M, ThCategory, [FreeCategory.Ob, FreeCategory.Hom])
+@test !implements(M, ThNatPlus, [FreeCategory.Ob, FreeCategory.Hom])
 @test impl_type(M, ThCategory, :Ob) == FreeCategory.Ob
 @test impl_type(M, ThCategory, :Hom) == FreeCategory.Hom
 @test ThCategory.id[M](x) isa HomExpr{:id}
@@ -398,4 +398,4 @@ zAB,zBC,zAC = zeromap(A,B),zeromap(B,C),zeromap(A,C)
 @test zAC == compose(f,zBC) == compose(zAB,g)
 @test compose(f,zBC,h) == zeromap(A,D)
 
-end
+end # module

--- a/test/models/tests.jl
+++ b/test/models/tests.jl
@@ -1,7 +1,8 @@
 module ModelTests
 
+include("SpecialModels.jl")
 include("ModelInterface.jl")
 include("SymbolicModels.jl")
 include("Presentations.jl")
 
-end
+end # module


### PR DESCRIPTION
This PR changes how GATlab tracks whether a model implements a theory. It removes the static typechecking which was often too underpowered to handle things which were morally correct. 

Before we had `implements` methods generated during `@instance` for each model type + scopetag. it would return some documentation if, e.g., `FinSetC` implements `compose` and otherwise a `MethodError` would be thrown as the method doesn't exist. In this new approach, an `impl_type(::FinSetC, x::Ident)` method gets generated which ....

This removes the need for `@import` when defining an extension of a model. 

This PR also adds special models (Dispatch, Initial, Terminal) which can be made sense of in any theory.