### PR TITLE
Define alias methods in `@instance` rather than `@theory`

### DIFF
--- a/src/models/SymbolicModels.jl
+++ b/src/models/SymbolicModels.jl
@@ -300,7 +300,7 @@ macro symbolic_model(decl, theoryname, body)
     theoryname,
     Dict(sort => :($name.$(nameof(sort))) for sort in sorts(theory)),
     nothing,
-    []
+    [],
   )
 
   Expr(


### PR DESCRIPTION
This *undoes* a change made earlier in this series of PRs where the code which generated alias was methods was changed. The change was to allow us to define just once 

```julia 
ThCategory2.*(anymodel::WithModel, xs...) = ThCategory2.composeH(anymodel, xs...)
```

whenever, e.g., `ThCategory2` is defined, rather than handling aliases for every single theory + model combination in the `@instance` code.

The issue only revealed itself towards the end of the Catlab refactor, when it became clear two different theories (`ThCategory2` and `ThCopresheaf`) both `import` the same symbol, `Base.:*` and made them aliases for *differently named* things (`composeH` and `act`, respectively). This means when the second theory is defined, we emit the code  

```julia 
ThCopresheaf.*(anymodel::WithModel, xs...) = ThCopresheaf.act(anymodel, xs...)
```

which actually *overwrites* the association of `Base.:*` with `ThCategory2.composeH` (it's alarming the Julia precompiler did not print a warning of method overwriting!).

So the alias methods are now generated only whenever the corresponding other method is generated (this is still capable of causing type conflicts, but these are much less likely because one must be using the same model with the same types).