### PR TITLE
Munging object name on Presentation

### DIFF
--- a/src/models/Presentations.jl
+++ b/src/models/Presentations.jl
@@ -88,8 +88,13 @@ function add_generator!(pres::Presentation, expr)
   name, type = first(expr), gat_typeof(expr)
   generators = pres.generators[type]
   if !isnothing(name)
-    if haskey(pres.generator_name_index, name)
-      error("Name $name already defined in presentation")
+    (name, expr) = if haskey(pres.generator_name_index, name)
+        new_name = Symbol("$(expr.args[2].args[1])_$name")
+        expr.args[1] = new_name
+        (new_name, expr)
+      # error("Name $name already defined in presentation")
+    else
+        name, expr
     end
     pres.generator_name_index[name] = type => length(generators)+1
   end


### PR DESCRIPTION
I am drafting this PR to resolve a two-ish year old Catlab [issue 828](https://github.com/AlgebraicJulia/Catlab.jl/issues/828), which desires unique pairs of homs within a schema. This feature would be useful especially in database applications, where any two tables (Obs) may have columns (homs/attrs) with the same name.

However this introduces some downstream implementation issues. For example, suppose someone wanted to define the following schema:
```julia
@present SchExample(FreeSchema) begin
    Name::AttrType
    (X, Y)::Ob
    name::Attr(X, Name)
    name::Attr(Y, Name)
end
```
The changes introduced by the first commit on this PR implies that since `name::Attr(X, Name)` is defined, rather than throwing an error it would munge the object associated to its domain. In our example, the second `name` becomes `Y_name`. However this unhappily changes data the user provides.

A slightly deeper change would be to reorganize the presentation to group names by type. For instance (pseudocode), 
```julia
# ... dictionary entries
Attr(X, Name) => [:name]
Attr(Y, Name) => [:name]
```
Therefore collision-checking would first check if the arguments of the `expr` collide, and _then_ whether the name does. Since `add_part!` mutates ACSets one part at a time, there should be no issues with keyword collision, as in the case here:
```
add_part!(acset, :X, name=:first)
add_part!(acset, :Y, name=:second)
```
Are there any hazards I'm not considering?