### PR TITLE
Allow WithModel with Dispatch models

### DIFF
--- a/src/syntax/TheoryInterface.jl
+++ b/src/syntax/TheoryInterface.jl
@@ -245,6 +245,7 @@ function juliadeclaration(name::Symbol)
     # we expect just one method because of Dispatch type
     if isempty(Base.methods(Base.getindex, [typeof($name), Any]))
       Base.getindex(f::typeof($name), ::$(GlobalRef(TheoryInterface, :Dispatch))) = f
+      $name(::$(GlobalRef(TheoryInterface, :WithModel)){$(GlobalRef(TheoryInterface, :Dispatch))}, args...) = $name(args...)
       Base.getindex(f::typeof($name), ::$(GlobalRef(TheoryInterface, :InitialModel′))) = (x...;kw...)->error("Cannot call")
       Base.getindex(f::typeof($name), ::$(GlobalRef(TheoryInterface, :TerminalModel′))) = (x...;kw...)->nothing
 

--- a/test/models/SpecialModels.jl
+++ b/test/models/SpecialModels.jl
@@ -41,7 +41,7 @@ ThCat.id(i::Int) = [i]
 @test implements(d, ThCat, [Int, Vector{Int}])
 
 @test id(1) == [1] == ThCat.id[d](1)
-@test compose[d]([1],[2,3]) == [1]
+@test compose[d]([1],[2,3]) == [1] == compose(WithModel(d), [1],[2,3])
 
 @test implements(d, ThCat, [Int, Vector{Int}])
 


### PR DESCRIPTION
Dispatch models are special models that have the meaning of "just use dispatch". Previously one could index a method with a dispatch model, i.e. `f[d](args...) = f(args...)`. However to be more consistent with normal models, we also need a `f(::WithModel{Dispatch}, args...) = f(args...)` method to be automatically generated for each theory operation.